### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [3/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-network.json
+++ b/chef/data_bags/crowbar/bc-template-network.json
@@ -232,6 +232,9 @@
   "deployment": {
     "network": {
       "crowbar-revision": 0,
+      "element_states": {
+        "network": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [ "network" ]

--- a/chef/data_bags/crowbar/bc-template-network.schema
+++ b/chef/data_bags/crowbar/bc-template-network.schema
@@ -116,6 +116,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-network.json   |    3 +++
 chef/data_bags/crowbar/bc-template-network.schema |   10 ++++++++++
 2 files changed, 13 insertions(+), 0 deletions(-)
