### PR TITLE
Add CentOS 6.2 support and rework our Chef hotpatching infrastructure. [3/7]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -98,7 +98,8 @@ rpms:
     - dhcp
     - tftp-server
     - nfs-utils
-
+    - iptables
+    - iptables-ipv6
 debs:
   ubuntu-10.10:
     pkgs:


### PR DESCRIPTION
This pull requests does 3 things:
- Add support for CentOS 6.2
- Have the admin node install die if it loses the machine role.
- Rework the Chef hotpatching stuff to make it a little less ad-hoc.
