### PR TITLE
Pull changes from development into essex-hack [13/16]

### DIFF
--- a/bin/crowbar_network
+++ b/bin/crowbar_network
@@ -18,9 +18,10 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), "barclamp_lib")
 @barclamp = "network"
 
-
-@commands["allocate_ip"] = [ "allocate_ip(ARGV.shift,ARGV.shift,ARGV.shift,ARGV.shift)", "allocate_ip <name> <node> <network> <range> - Allocate an ip for a name on a network from a range" ]
+@commands["deallocate_ip"] = [ "deallocate_ip(ARGV.shift,ARGV.shift,ARGV.shift)", "deallocate_ip <name> <node> <network> - Deallocate an ip from a node on a network" ]
+@commands["allocate_ip"] = [ "allocate_ip(ARGV.shift,ARGV.shift,ARGV.shift,ARGV.shift,ARGV.shift)", "allocate_ip <name> <node> <network> <range> [<suggestion>] - Allocate an ip for a node on a network from a range" ]
 @commands["enable_interface"] = [ "enable_interface(ARGV.shift,ARGV.shift,ARGV.shift)", "enable_interface <name> <node> <network> - Ensure that an interface is present for the specified network" ]
+@commands["disable_interface"] = [ "disable_interface(ARGV.shift,ARGV.shift,ARGV.shift)", "disable_interface <name> <node> <network> - Ensure that an interface is not enabled for the specified network" ]
 
 def enable_interface(name, node, network)
   usage -1 if name.nil? or name == ""
@@ -31,33 +32,73 @@ def enable_interface(name, node, network)
   struct = post_json("/enable_interface/#{name}", @data)
 
   if struct[1] == 200
-    [ "Edited #{name} #{struct[0].inspect}", 0 ]
+    [ "Enabled interface #{name} #{struct[0].inspect}", 0 ]
   elsif struct[1] == 404
-    [ "Failed to edit: #{name} : Not Found", 1 ]
+    [ "Failed to enable interface: #{name} : Not Found", 1 ]
   elsif struct[1] == 400
-    [ "Failed to edit: #{name} : Errors in data\n#{struct[0]}", 1 ]
+    [ "Failed to enable interface: #{name} : Errors in data\n#{struct[0]}", 1 ]
   else
     [ "Failed to talk to service enable_interface: #{struct[1]}: #{struct[0]}", 1 ]
   end
 end
 
-def allocate_ip(name, node, network, range)
+def allocate_ip(name, node, network, range, suggestion)
   usage -1 if name.nil? or name == ""
   usage -1 if network.nil? or network == ""
   usage -1 if node.nil? or node == ""
   usage -1 if range.nil? or range == ""
 
-  @data = { "name" => node, "network" => network, "range" => range }.to_json
+  @data = { "name" => node, "network" => network, "range" => range }
+  @data["suggestion"] = suggestion if suggestion
+  @data = @data.to_json
   struct = post_json("/allocate_ip/#{name}", @data)
 
   if struct[1] == 200
-    [ "Edited #{name} #{struct[0].inspect}", 0 ]
+    [ "Allocate ip #{name} #{struct[0].inspect}", 0 ]
   elsif struct[1] == 404
-    [ "Failed to edit: #{name} : Not Found", 1 ]
+    [ "Failed to Allocate ip: #{name} : Not Found", 1 ]
   elsif struct[1] == 400
-    [ "Failed to edit: #{name} : Errors in data\n#{struct[0]}", 1 ]
+    [ "Failed to Allocate ip: #{name} : Errors in data\n#{struct[0]}", 1 ]
   else
     [ "Failed to talk to service allocate_ip: #{struct[1]}: #{struct[0]}", 1 ]
+  end
+end
+
+def deallocate_ip(name, node, network)
+  usage -1 if name.nil? or name == ""
+  usage -1 if network.nil? or network == ""
+  usage -1 if node.nil? or node == ""
+
+  @data = { "name" => node, "network" => network }.to_json
+  struct = post_json("/deallocate_ip/#{name}", @data)
+
+  if struct[1] == 200
+    [ "Deallocate address #{network} #{node}", 0 ]
+  elsif struct[1] == 404
+    [ "Failed to deallocate ip: #{name} : Not Found", 1 ]
+  elsif struct[1] == 400
+    [ "Failed to deallocate ip: #{name} : Errors in data\n#{struct[0]}", 1 ]
+  else
+    [ "Failed to talk to service deallocate_ip: #{struct[1]}: #{struct[0]}", 1 ]
+  end
+end
+
+def disable_interface(name, node, network)
+  usage -1 if name.nil? or name == ""
+  usage -1 if node.nil? or node == ""
+  usage -1 if network.nil? or network == ""
+
+  @data = { "name" => node, "network" => network }.to_json
+  struct = post_json("/disable_interface/#{name}", @data)
+
+  if struct[1] == 200
+    [ "Disable interface #{network} #{node}", 0 ]
+  elsif struct[1] == 404
+    [ "Failed to disable interface: #{name} : Not Found", 1 ]
+  elsif struct[1] == 400
+    [ "Failed to disable interface: #{name} : Errors in data\n#{struct[0]}", 1 ]
+  else
+    [ "Failed to talk to service disable_interface: #{struct[1]}: #{struct[0]}", 1 ]
   end
 end
 

--- a/chef/data_bags/crowbar/bc-template-network.json
+++ b/chef/data_bags/crowbar/bc-template-network.json
@@ -243,7 +243,7 @@
         "environment": "network-base-config",
         "mode": "full",
         "transitions": true,
-        "transition_list": [ "discovered" ]
+        "transition_list": [ "discovered", "reset", "delete" ]
       }
     }
   }

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -19,6 +19,7 @@ barclamp:
   name: network
   display: Network
   version: 0
+  online_help: 'https://github.com/dellcloudedge/crowbar/wiki/Network--barclamp'
   member:
     - crowbar
 
@@ -75,6 +76,13 @@ locale_additions:
         inuse: Active
         not_inuse: X
         nodes: Nodes
+      nodes:
+        title: Interface and Conduit Maps
+        interface_map: Interface Map for Network Attributes
+        node: Node
+        model: Model
+        has_map: Mapped
+        
 
 rpms:
   redhat-5.6:
@@ -98,7 +106,8 @@ rpms:
     - dhcp
     - tftp-server
     - nfs-utils
-
+    - iptables
+    - iptables-ipv6
 debs:
   ubuntu-10.10:
     pkgs:

--- a/crowbar_framework/app/controllers/network_controller.rb
+++ b/crowbar_framework/app/controllers/network_controller.rb
@@ -20,20 +20,30 @@ class NetworkController < BarclampController
     @service_object = NetworkService.new logger
   end
 
-  # Below here handles ip address assignment.
   add_help(:allocate_ip,[:id,:network,:range,:name],[:post])
   def allocate_ip
     id = params[:id]       # Network id
     network = params[:network]
     range = params[:range]
     name = params[:name]
+    suggestion = params[:suggestion]
 
-    ret = @service_object.allocate_ip(id, network, range, name)
+    ret = @service_object.allocate_ip(id, network, range, name, suggestion)
     return render :text => ret[1], :status => ret[0] if ret[0] != 200
     render :json => ret[1]
   end
 
-  # Below here handles ip address assignment.
+  add_help(:deallocate_ip,[:id,:network,:name],[:post])
+  def deallocate_ip
+    id = params[:id]       # Network id
+    network = params[:network]
+    name = params[:name]
+
+    ret = @service_object.deallocate_ip(id, network, name)
+    return render :text => ret[1], :status => ret[0] if ret[0] != 200
+    render :json => ret[1]
+  end
+
   add_help(:enable_interface,[:id,:network,:name],[:post])
   def enable_interface
     id = params[:id]       # Network id
@@ -41,6 +51,17 @@ class NetworkController < BarclampController
     name = params[:name]
 
     ret = @service_object.enable_interface(id, network, name)
+    return render :text => ret[1], :status => ret[0] if ret[0] != 200
+    render :json => ret[1]
+  end
+
+  add_help(:disable_interface,[:id,:network,:name],[:post])
+  def disable_interface
+    id = params[:id]       # Network id
+    network = params[:network]
+    name = params[:name]
+
+    ret = @service_object.disable_interface(id, network, name)
     return render :text => ret[1], :status => ret[0] if ret[0] != 200
     render :json => ret[1]
   end
@@ -93,6 +114,32 @@ class NetworkController < BarclampController
     
   end
   
+  def nodes
+
+    net_bc = RoleObject.find_role_by_name 'network-config-default'
+    @map = net_bc.default_attributes['network']['interface_map'] if net_bc.barclamp == 'network'
+    @patterns = {}
+    @interfaces = []
+    @map.each do |maps|
+      @patterns[maps['pattern']] = maps['bus_order']
+    end
+    
+    if params[:id]
+      @node = NodeObject.find_node_by_name params[:id]
+    end
+    
+    @nodes = NodeObject.all
+    @nodes.each do |node|
+      if node.crowbar_ohai and node.crowbar_ohai["detected"] and node.crowbar_ohai["detected"]["network"]
+        node.crowbar_ohai["detected"]['network'].each do |intf, address|
+          @interfaces << intf unless @interfaces.include? intf
+        end
+      end
+    end
+    @interfaces = @interfaces.sort
+    
+  end
+    
   private 
   
   def node_vlans(node)

--- a/crowbar_framework/app/views/network/nodes.html.haml
+++ b/crowbar_framework/app/views/network/nodes.html.haml
@@ -1,0 +1,68 @@
+%h2= t('.title')
+
+.column_100
+  - if @node
+    %section.box#details
+      %h3= t('.interface_map')
+      %ul
+        %li= "{ \"pattern\": \"#{@node.hardware}\","
+        %li= "\"bus_order\": ["
+        %li
+          %ul
+            - i = 1
+            - @node.crowbar_ohai['detected']['network'].each do |intf, pattern|
+              - p = pattern.split('/')
+              %li
+                = "\"#{p[0]}/#{p[1]}\""
+                = "," if i < @node.crowbar_ohai['detected']['network'].length
+                - i +=1
+        %li= "] },"
+
+%table.data.box
+  %thead
+    %tr
+      %th= t('.node')
+      %th= t('.model')
+      %th= t('.has_map')
+      -@interfaces.each do |intf|
+        %th= intf
+  %tbody
+    -if @nodes
+      -@nodes.sort_by{ |n| n.alias}.each do |node|
+        - patterns = nil
+        - @patterns.each do |k, v|
+          - if node.hardware =~ /^#{k}/
+            - patterns = v
+            - break 
+        - addr_list = []
+        - if node.crowbar_ohai and node.crowbar_ohai['detected'] and node.crowbar_ohai['detected']['network'] 
+          - addresses = node.crowbar_ohai['detected']['network'] 
+          - addresses.each { |k, v| addr_list << "#{k}=#{v}" }
+        %tr
+          %td{:title=>node.description}= link_to node.alias, node_path(:name=>node.handle)
+          - if addresses
+            %td{:title=>addr_list.join(", ")}= link_to node.hardware, nodes_barclamp_path(:controller=>'network', :id=>node.handle)
+          - else
+            %td= node.hardware
+          - if patterns
+            %td{:title=>patterns.join(', ')}= t('yes')
+          - else
+            %td= t('no')
+          - @interfaces.each do |intf|
+            - if patterns and addresses 
+              - address = addresses[intf]
+              - if address
+                - a = address.split('/')
+                - i = patterns.index("#{a[0]}/#{a[1].split('.')[0]}")
+                %td{:title=>patterns[i]}= "1g#{i+1}"
+              - else
+                %td
+            - else
+              %td
+    -else
+      %tr
+        %td{:colspan=>(3+@interfaces.length)}
+          = t('no_items')
+  %tfoot
+    %tr
+      %td{:colspan=>(3+@interfaces.length)}


### PR DESCRIPTION
Synchronize essex-hack with development. Among other things, this
pulls in:
- Numerous UI improvements.
- Enhancements and bugfixes galore in the dev tool and build system.
- Sledgehammer on CentOS 6.2 support.
- Somewhat more standardized patch management for our Chef and Rails
  patches.

This pull request series has been smoketested on virtual machines, and
is able to spin up vms in Nova using the dashboard.

 bin/crowbar_network                                |   61 +++++++++--
 chef/data_bags/crowbar/bc-template-network.json    |    2 +-
 crowbar.yml                                        |   11 ++-
 .../app/controllers/network_controller.rb          |   53 +++++++++-
 crowbar_framework/app/models/network_service.rb    |  108 +++++++++++++++++++-
 .../app/views/network/nodes.html.haml              |   68 ++++++++++++
 6 files changed, 283 insertions(+), 20 deletions(-)
