### PR TITLE
Update the test framework to use a teamed network.json [2/7]

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -25,12 +25,10 @@ def sort_interfaces(interfaces)
   seq=0
   i=interfaces.keys.sort
   until i.empty?
-    Chef::Log.debug("Processing interfaces #{i.inspect}")
     i.each do |ifname|
       iface=interfaces[ifname]
       iface[:interface_list] ||= Array.new
       iface[:interface_list] = iface[:interface_list].sort
-      Chef::Log.debug("#{ifname}: #{iface.inspect}")
       # If this interface has children, and any of its children have not
       # been given a sequence number, skip it.
       next if not iface[:interface_list].empty? and 
@@ -157,7 +155,7 @@ end
 
 def crowbar_interfaces()
   conduit_map = Barclamp::Inventory.build_node_map(node)
-  Chef::Log.debug("Conduit mapping for this node:  #{conduit_map.inspect}")
+  Chef::Log.info("Conduit mapping for this node:  #{conduit_map.inspect}")
   res = Hash.new
   # seems that we can only have 1 bonding mode is possible per machine
   machine_team_mode = nil
@@ -168,13 +166,13 @@ def crowbar_interfaces()
   node["crowbar"]["network"].each { |name, network | 
     r_pref = 10000
     r_pref= Integer(network["router_pref"]) if network["router_pref"]
-    log("eval router from #{name}, pref #{r_pref}")  { level :warn }
+    Chef::Log.debug("eval router from #{name}, pref #{r_pref}")
     if (r_pref < max_pref)
       max_pref = r_pref
       net_pref = name
     end
   }
-  log("will allow routers from #{net_pref}") { level :warn }
+  Chef::Log.info("will allow routers from #{net_pref}")
   node["crowbar"]["network"].each do |netname, network|
     next if netname == "bmc"
     allow_gw = (netname == net_pref)
@@ -182,8 +180,8 @@ def crowbar_interfaces()
     conduit = network["conduit"]
     intf, interface_list, tm = Barclamp::Inventory.lookup_interface_info(node, conduit, conduit_map)
     if intf.nil?
-      log("No conduit for interface: #{conduit}") { level :fatal }
-      log("Refusing to do so.") { level :fatal }
+      Chef::Log.fatal("No conduit for interface: #{conduit}")
+      Chef::Log.fatal("Refusing to do so.")
       raise ::RangeError.new("No conduit to interface map for #{conduit}")
     end
 
@@ -192,7 +190,7 @@ def crowbar_interfaces()
       machine_team_mode = tm if machine_team_mode.nil?
       if (!machine_team_mode.nil? and !machine_team_mode == tm)
           # once a bonding mode has been selected for the machine, don't let others...
-	  Chef::Provider::Log::ChefLog.log("CONFLICTING TEAM MODES: for conduit #{conduit}")
+	  Chef::Log.warn("CONFLICTING TEAM MODES: for conduit #{conduit}")
       end
       res[intf] = Hash.new unless res[intf]
       res[intf][:interface_list] = interface_list
@@ -347,12 +345,12 @@ def deorder(i)
   i.reject{|k,v|k == :order or v.nil? or (v.respond_to?(:empty?) and v.empty?)}
 end
 
-log("Current interfaces:\n#{old_interfaces.inspect}\n") { level :debug }
-log("New interfaces:\n#{new_interfaces.inspect}\n") { level :debug }
+Chef::Log.info("Current interfaces:\n#{old_interfaces.inspect}\n")
+Chef::Log.info("New interfaces:\n#{new_interfaces.inspect}\n")
 
 if (not new_interfaces) or new_interfaces.empty?
-  log("Crowbar instructed us to tear down all our interfaces!") { level :fatal }
-  log("Refusing to do so.") { level :fatal }
+  Chef::Log.fatal("Crowbar instructed us to tear down all our interfaces!")
+  Chef::Log.fatal("Refusing to do so.")
   raise ::RangeError.new("Not enough active network interfaces.")
 else
   # Third, rewrite the network configuration to match the new config.
@@ -376,12 +374,12 @@ else
   # Second, examine each interface that exists in both the old and the
   # new configuration to see what changed, and take appropriate action.
   (old_interfaces.keys & new_interfaces.keys).each {|i|
-    log("Transitioning #{i}:\n#{old_interfaces[i].inspect}\n=>\n#{new_interfaces[i].inspect}\n") { level :debug }
+    Chef::Log.info("Transitioning #{i}:\n#{old_interfaces[i].inspect}\n=>\n#{new_interfaces[i].inspect}\n")
     case
     when deorder(old_interfaces[i]) == deorder(new_interfaces[i])
       # The only thing that changed is the proposed position in the interfaces
       # file.  Don't do anything with this interface.
-      log "#{i} did not change, skipping."
+      Chef::Log.info("#{i} did not change, skipping.")
       next
     when old_interfaces[i][:config] == "dhcp"
       # We are going to transition an interface into being owned by Crowbar.
@@ -426,7 +424,7 @@ else
   (old_interfaces.keys - new_interfaces.keys).sort{|a,b| 
     old_interfaces[b][:order] <=> old_interfaces[a][:order]}.each {|i|
     next if i.nil? or i == ""
-    log("Removing #{old_interfaces[i]}\n") { level :debug }
+    Chef::Log.info("Removing #{old_interfaces[i]}\n")
     bash "ifdown #{i} for removal" do
       code "ifdown #{i}"
       ignore_failure true
@@ -465,7 +463,7 @@ else
   
   # If we need to sleep now, do it.
   delay_time = delay ? node["network"]["start_up_delay"] : 0
-  log "Sleeping for #{delay_time} seconds due new link coming up"
+  Chef::Log.info "Sleeping for #{delay_time} seconds due new link coming up"
   bash "network delay sleep" do
     code "sleep #{delay_time}"
     only_if { delay != 0 }


### PR DESCRIPTION
In the process of adding support or this, I also added:
- Use screen to run the actaul installation of crowbar on the admin
  node.  This also makes the installation process much less fragile in
  the face of changing network interface configurations.
- Have the test framework kick off the admin node install via SSH
  instead of using the crowbar.hostname hack.
- Make crowbar_ohai ignore any network interfaces that are not
  directly backed by a physical device.  This makes the condiut
  mapping code much more stable when adding or removing devices that
  act like a virtual ethernet device.
  
  chef/cookbooks/network/recipes/default.rb |  103 +++++++++++++++--------------
  1 files changed, 54 insertions(+), 49 deletions(-)
