### PR TITLE
Further fixes for the network barclamp and the provisioner [1/6]

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -419,12 +419,7 @@ end
     else
       # We are giving it a manual config.  Ifdown the interface, and then
       # schedule it to be ifup'ed based on whether or not :auto is true.
-      bash "ifdown #{i} for crowbar capture" do
-        code "ifdown #{i}"
-        ignore_failure true
-      end
       interfaces_to_up[i] = "ifup #{i}" if new_interfaces[i][:auto]
-      delay = true
     end
   else
     Chef::Log.info("Transitioning #{i}:\n#{old_interfaces[i].inspect}\n=>\n#{new_interfaces[i].inspect}\n")


### PR DESCRIPTION
- crowbar_join.sh now runs under screen on the computer nodes.  This
  lets you login when crowbar_join.sh is stuck in an infinite loop.
- Sledgehammer recipies have been updated to include lvm.
- The test framework knows how to talk to all the networks that
  Crowbar might bring up.  It also knows how to tell the admin node to
  do the same thing.
- The network barclamp no longer has to tear down an interface and
  bring it back up because the default route changed.
- The network barclamp now only delays if a physical interface had to
  be reconfigured, which should be the only thing that might trigger
  STP renegotiation on the switch.
  
  chef/cookbooks/network/recipes/default.rb |  249 +++++++++++++++--------------
  1 files changed, 131 insertions(+), 118 deletions(-)
