### PR TITLE
Fix nodes cycling in hardware installing [1/5]

### DIFF
--- a/chef/cookbooks/network/recipes/switch_config.rb
+++ b/chef/cookbooks/network/recipes/switch_config.rb
@@ -63,6 +63,7 @@ search(:node, "*:*").each do |a_node|
     switch_ports = {}
     if_list.each do |intf|
       sw=a_node["crowbar_ohai"]["switch_config"][intf] rescue {}
+      next if sw.nil?
       next unless sw["switch_name"] && sw["switch_port"] && sw["switch_port_name"]
       next if sw["switch_port"] == -1
       switch_name=sw["switch_name"]


### PR DESCRIPTION
Added more null checking in switch_config.rb to prevent nodes from
cycling over hardware installing.

 chef/cookbooks/network/recipes/switch_config.rb |    1 +
 1 files changed, 1 insertions(+), 0 deletions(-)
