### PR TITLE
Documentation System for Crowbar [2/7]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -69,12 +69,12 @@ locale_additions:
       dense:
         no_connection: No Connection
       vlan:
-        title: Available VLANs
+        title: Available Networks
         name: Name
         id: VLAN ID
         conduit: Conduit
-        inuse: Active
-        not_inuse: X
+        inuse: Active VLAN
+        not_inuse: Untagged
         nodes: Nodes
       nodes:
         title: Interface and Conduit Maps


### PR DESCRIPTION
This addition (currently in DevMode only) reflects a desire to move 
away from PDF based help and to something that can be tracked
and managed with the code for each barclamp itself.

This change includes some stubs for documentation in the doc directory that 
need to be expanded based on the current documentation. The docs require
meta data at the top of each file to build the master index.

By default the docs are in markdown, but could be in any format
that pandoc supports (including textile). Pandoc is used to create the
small html pages that are viewed for the topics.

It is designed to be in smaller topic chunks rather than a single doc.

The basics are /docs will show (and generate) a master index with three
levels of nesting

Each topic can be viewed as /docs/topic/:id. The topics will have navigation
aids for root, parent, next, and previous.

NEED TO ADD CONTENT NEXT!

 crowbar.yml |    6 +++---
 1 files changed, 3 insertions(+), 3 deletions(-)
