### PR TITLE
Update network-nodes view to use correct conduit and interface info [1/5]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -81,8 +81,23 @@ locale_additions:
         interface_map: Interface Map for Network Attributes
         node: Node
         model: Model
-        has_map: Mapped
-        
+        mode: Network Mapping Mode
+        default_bus_order: Using Default Interface (Bus) Ordering
+        bus_order: Interface (Bus) Order Map
+        conduit_mgmt: Management
+        conduit_bmc: 'BMC/IMPI'
+        conduit_prod: Production
+        conduit_public: 'Public/Guest'
+        conduit_intf0: Default
+        conduit_intf1: First Interface
+        conduit_intf2: Second Interface
+        conduit_intf3: Third Interface
+        team_1: Team Mode 1
+        team_2: Team Mode 2
+        team_3: Team Mode 3
+        team_4: Team Mode 4
+        team_5: Team Mode 5
+        team_6: Team Mode 6
 
 rpms:
   redhat-5.6:

--- a/crowbar_framework/app/views/network/nodes.html.haml
+++ b/crowbar_framework/app/views/network/nodes.html.haml
@@ -1,68 +1,38 @@
+%p{:style => 'float:right'}
+  = t('.mode')+":"
+  %strong= @mode
 %h2= t('.title')
 
-.column_100
-  - if @node
-    %section.box#details
-      %h3= t('.interface_map')
-      %ul
-        %li= "{ \"pattern\": \"#{@node.hardware}\","
-        %li= "\"bus_order\": ["
-        %li
-          %ul
-            - i = 1
-            - @node.crowbar_ohai['detected']['network'].each do |intf, pattern|
-              - p = pattern.split('/')
-              %li
-                = "\"#{p[0]}/#{p[1]}\""
-                = "," if i < @node.crowbar_ohai['detected']['network'].length
-                - i +=1
-        %li= "] },"
+-if @active_mode != @mode
+  %div= t '.not_active_mode'
 
 %table.data.box
   %thead
     %tr
       %th= t('.node')
       %th= t('.model')
-      %th= t('.has_map')
-      -@interfaces.each do |intf|
-        %th= intf
+      -@conduits.each do |conduit|
+        %th{:title=>conduit}= t '.conduit_'+conduit, :default=>conduit.humanize
   %tbody
     -if @nodes
-      -@nodes.sort_by{ |n| n.alias}.each do |node|
-        - patterns = nil
-        - @patterns.each do |k, v|
-          - if node.hardware =~ /^#{k}/
-            - patterns = v
-            - break 
-        - addr_list = []
-        - if node.crowbar_ohai and node.crowbar_ohai['detected'] and node.crowbar_ohai['detected']['network'] 
-          - addresses = node.crowbar_ohai['detected']['network'] 
-          - addresses.each { |k, v| addr_list << "#{k}=#{v}" }
+      -@nodes.sort_by{ |handle, node| node[:alias]}.each do |handle, node|
         %tr
-          %td{:title=>node.description}= link_to node.alias, node_path(:name=>node.handle)
-          - if addresses
-            %td{:title=>addr_list.join(", ")}= link_to node.hardware, nodes_barclamp_path(:controller=>'network', :id=>node.handle)
-          - else
-            %td= node.hardware
-          - if patterns
-            %td{:title=>patterns.join(', ')}= t('yes')
-          - else
-            %td= t('no')
-          - @interfaces.each do |intf|
-            - if patterns and addresses 
-              - address = addresses[intf]
-              - if address
-                - a = address.split('/')
-                - i = patterns.index("#{a[0]}/#{a[1].split('.')[0]}")
-                %td{:title=>patterns[i]}= "1g#{i+1}"
-              - else
-                %td
-            - else
-              %td
+          %td{:title=>node[:description]}= link_to node[:alias], node_path(:name=>handle)
+          -if node[:bus]
+            %td{:title=>"#{t('.bus_order')}: #{node[:bus].join(', ')}"}= node[:model]
+          -else
+            %td{:title=>t('.default_bus_order')}= node[:model]
+          - @conduits.each do |conduit|
+            %td
+              -if node[:conduits]
+                - intf = node[:conduits][conduit]
+                - if intf and intf["if_list"]
+                  = t('.team_'+intf["team_mode"].to_s, :default=>'Team '+intf["team_mode"].to_s)+': ' if intf and intf["team_mode"]
+                  = intf["if_list"].join(', ') if intf["if_list"]
     -else
       %tr
-        %td{:colspan=>(3+@interfaces.length)}
+        %td{:colspan=>(3+@conduits.length)}
           = t('no_items')
   %tfoot
     %tr
-      %td{:colspan=>(3+@interfaces.length)}
+      %td{:colspan=>(3+@conduits.length)}


### PR DESCRIPTION
My first attempt at a network/nodes view was not correct.

This pass, advised by Greg A, uses the node networking methods
to build an accurate Conduit and Intf map per node.

This view is important because it helps visualize and review some of the 
complex interractions that go on with the network barclamp.

TODO:
- reflect which pattern is being used (not just the interfaces)
- (considering) show the IP assigned to the interface.
- show VLAN information if assigned.
  
  crowbar.yml                                        |   19 +++++-
  .../app/controllers/network_controller.rb          |   34 +++++-----
  .../app/views/network/nodes.html.haml              |   74 ++++++--------------
  3 files changed, 56 insertions(+), 71 deletions(-)
