### PR TITLE
Fix barclamp installation bug when there are no chef recipes [1/5]

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -110,7 +110,6 @@ node["crowbar"]["network"].keys.sort{|a,b|
     end
     ifs[bond.name]["mode"] = team_mode
     ifs[bond.name]["type"] = "bond"
-    Chef::Log.info("Using bond #{bond.name} for network #{name}")
     our_iface = bond
   end
   net_ifs << our_iface.name


### PR DESCRIPTION
See title.

 chef/cookbooks/network/recipes/default.rb |   17 ++++++++++++-----
 1 file changed, 12 insertions(+), 5 deletions(-)
