### PR TITLE
Add online mode for the provisioner and experimental online-install functionality [5/10]

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -32,6 +32,12 @@ when "centos","redhat","suse"
   end
 end
 
+if ::File.exists?("/etc/init/network-interface.conf")
+  # Make upstart stop trying to dynamically manage interfaces.
+  ::File.unlink("/etc/init/network-interface.conf")
+  ::Kernel.system("killall -HUP init")
+end
+
 provisioner = search(:node, "roles:provisioner-server")[0]
 conduit_map = Barclamp::Inventory.build_node_map(node)
 Chef::Log.debug("Conduit mapping for this node:  #{conduit_map.inspect}")


### PR DESCRIPTION
This pull request series add 2 new features to Crowbar:

 1: Online mode for the provisioner.
    This enables the provisioner to be able to update deb/rpm/gem
    packages from sources on the Internet.

```
See README.package-updates for details on how this works and how
to enable it.
```

 2: Experimental full online-install mode.
    This leverages the infrastructure added for the provisioner to
    allow for installation of an admin node starting with a basic OS
    install and a checkout of the main Crowbar repository.  This is
    mainly useful right node for development purposes, and is under
    active development.  Most things work, but expect weird corner
    cases.

```
See README.online-install for more details.
```
