### PR TITLE
Move Nav into a database and adjust imaged locationalization [11/15]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -1,4 +1,4 @@
-# Copyright 2011, Dell
+# Copyright 2012, Dell
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author: RobHirschfeld
 #
 
 barclamp:
@@ -28,76 +27,6 @@ crowbar:
   order: 20
   run_order: 20
   chef_order: 20
-
-nav:
-  network:
-    switch: switch_path
-    vlan: vlan_path
-    
-locale_additions:
-  en:
-    barclamp:
-      network:
-        edit_attributes: 
-          attributes: Attributes
-        edit_deployment: 
-          deployment: Deployment
-    nav:
-      switch: Switches
-      vlan: VLANs
-    network:
-      vlan_names:
-        admin: Admin
-        bmc: Mgmt (BMC)
-        bmc_vlan: Mgmt Connect
-        nova_fixed: Nova Fixed
-        nova_floating: Nova Floating
-        public: Public
-        private: Private
-        storage: Storage
-      controller:
-        virtual: Virtual
-      switch:
-        title: Network Switches
-        switch_details: Switch Expanded Details
-        switch: Switch
-        port: Port
-        node: Node
-        nc: N/C
-        no_connection: No Connection
-        all: Show All
-      dense:
-        no_connection: No Connection
-      vlan:
-        title: Available Networks
-        name: Name
-        id: VLAN ID
-        conduit: Conduit
-        inuse: Active VLAN
-        not_inuse: Untagged
-        nodes: Nodes
-      nodes:
-        title: Interface and Conduit Maps
-        interface_map: Interface Map for Network Attributes
-        node: Node
-        model: Model
-        mode: Network Mapping Mode
-        default_bus_order: Using Default Interface (Bus) Ordering
-        bus_order: Interface (Bus) Order Map
-        conduit_mgmt: Management
-        conduit_bmc: 'BMC/IMPI'
-        conduit_prod: Production
-        conduit_public: 'Public/Guest'
-        conduit_intf0: Default
-        conduit_intf1: First Interface
-        conduit_intf2: Second Interface
-        conduit_intf3: Third Interface
-        team_1: Team Mode 1
-        team_2: Team Mode 2
-        team_3: Team Mode 3
-        team_4: Team Mode 4
-        team_5: Team Mode 5
-        team_6: Team Mode 6
 
 rpms:
   redhat-5.6:

--- a/crowbar_framework/config/locales/network/en.yml
+++ b/crowbar_framework/config/locales/network/en.yml
@@ -1,0 +1,81 @@
+# Copyright 2012, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+en:
+  nav:
+    switch: Switches
+    switch_description: Visual Representation of Switch Connections
+    vlan: VLANs
+    vlan_description: VLAN to Node Mapping
+    
+  barclamp:
+    network:
+      edit_attributes: 
+        attributes: Attributes
+      edit_deployment: 
+        deployment: Deployment
+
+  network:
+    vlan_names:
+      admin: Admin
+      bmc: Mgmt (BMC)
+      bmc_vlan: Mgmt Connect
+      nova_fixed: Nova Fixed
+      nova_floating: Nova Floating
+      public: Public
+      private: Private
+      storage: Storage
+    controller:
+      virtual: Virtual
+    switch:
+      title: Network Switches
+      switch_details: Switch Expanded Details
+      switch: Switch
+      port: Port
+      node: Node
+      nc: N/C
+      no_connection: No Connection
+      all: Show All
+    dense:
+      no_connection: No Connection
+    vlan:
+      title: Available Networks
+      name: Name
+      id: VLAN ID
+      conduit: Conduit
+      inuse: Active VLAN
+      not_inuse: Untagged
+      nodes: Nodes
+    nodes:
+      title: Interface and Conduit Maps
+      interface_map: Interface Map for Network Attributes
+      node: Node
+      model: Model
+      mode: Network Mapping Mode
+      default_bus_order: Using Default Interface (Bus) Ordering
+      bus_order: Interface (Bus) Order Map
+      conduit_mgmt: Management
+      conduit_bmc: 'BMC/IMPI'
+      conduit_prod: Production
+      conduit_public: 'Public/Guest'
+      conduit_intf0: Default
+      conduit_intf1: First Interface
+      conduit_intf2: Second Interface
+      conduit_intf3: Third Interface
+      team_1: Team Mode 1
+      team_2: Team Mode 2
+      team_3: Team Mode 3
+      team_4: Team Mode 4
+      team_5: Team Mode 5
+      team_6: Team Mode 6

--- a/crowbar_framework/db/migrate/20120724220000_network_navs.rb
+++ b/crowbar_framework/db/migrate/20120724220000_network_navs.rb
@@ -1,0 +1,28 @@
+# Copyright 2012, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+class NetworkNavs < ActiveRecord::Migration
+  def self.up
+    
+    Nav.find_or_create_by_item :item=>'switches', :parent_item=>'network', :name=>'nav.switch', :description=>'nav.switch_description', :path=>"switch_path", :order=>500
+    Nav.find_or_create_by_item :item=>'vlan', :parent_item=>'network', :name=>'nav.vlan', :description=>'nav.vlan_description', :path=>"vlan_path", :order=>600
+
+  end
+
+  def self.down
+    Nav.delete_by_item 'switches'
+    Nav.delete_by_item 'vlan'
+  end
+end


### PR DESCRIPTION
This work surfaced as part of the exploration to ensure that
multiple barclamps could contribute migrations (they can!)

Navigation has moved from the config/navigation into database
migrations that populate the navs table.  This means that nav
is no longer part of crowbar.yml.

Localization files are now unique per barclamp and not injected
during the barclamp import.  This provides more flexiblity and
easier management.  Localizations are no longer part of the crowbar.yml.

Documentation for the changes IS PROVIDED in the book-developersguide file.

For now, you need to rake db:migrate to get these changes!

 crowbar.yml                                        |   73 +-----------------
 crowbar_framework/config/locales/network/en.yml    |   81 ++++++++++++++++++++
 .../db/migrate/20120724220000_network_navs.rb      |   28 +++++++
 3 files changed, 110 insertions(+), 72 deletions(-)
