### PR TITLE
Re-factor out inialize methods as it caused layout to fail in rails3 [7/11]

### DIFF
--- a/crowbar_framework/app/controllers/network_controller.rb
+++ b/crowbar_framework/app/controllers/network_controller.rb
@@ -16,10 +16,15 @@
 class NetworkController < BarclampController
   # Make a copy of the barclamp controller help
   self.help_contents = Array.new(superclass.help_contents)
-  def initialize
+ 
+  before_filter :set_service_object
+ 
+  def set_service_object
     @service_object = NetworkService.new logger
   end
 
+  private :set_service_object
+  
   add_help(:allocate_ip,[:id,:network,:range,:name],[:post])
   def allocate_ip
     id = params[:id]       # Network id


### PR DESCRIPTION
Fixed problem with layout rendering due to initialize method not calling super.  Refactored to use before_filter method to load @service_object and deleted initialize method.

 .../app/controllers/network_controller.rb          |  371 ++++++++++----------
 1 files changed, 188 insertions(+), 183 deletions(-)
