### PR TITLE
Switch Port 0 detection fix [1/5]

### DIFF
--- a/crowbar_framework/app/controllers/network_controller.rb
+++ b/crowbar_framework/app/controllers/network_controller.rb
@@ -72,6 +72,7 @@ class NetworkController < BarclampController
     @groups = {}
     @switches = {}
     @nodes = {}
+    @port_start = 1
     nodes = (params[:node] ? NodeObject.find_nodes_by_name(params[:node]) : NodeObject.all)
     nodes.each do |node|
       @sum = @sum + node.name.hash
@@ -85,12 +86,13 @@ class NetworkController < BarclampController
       node_nics(node).each do |switch|
         key = switch[:switch]
         if key
-          @switches[key] = { :status=>{"ready"=>0, "failed"=>0, "unknown"=>0, "unready"=>0, "pending"=>0}, :nodes=>{}, :max_port=>24} unless @switches.key? key
+          @switches[key] = { :status=>{"ready"=>0, "failed"=>0, "unknown"=>0, "unready"=>0, "pending"=>0}, :nodes=>{}, :max_port=>(23+@port_start)} unless @switches.key? key
           port = if switch['switch_port'] == -1 or switch['switch_port'] == "-1"
             @vports[key] = 1 + (@vports[key] || 0)
           else
             switch[:port]
           end
+          @port_start = 0 if port == 0
           @switches[key][:max_port] = port if port>@switches[key][:max_port]
           @switches[key][:nodes][port] = { :handle=>node.handle, :intf=>switch[:intf] }
           @switches[key][:status][node.status] = (@switches[key][:status][node.status] || 0).to_i + 1

--- a/crowbar_framework/app/views/network/switch.html.haml
+++ b/crowbar_framework/app/views/network/switch.html.haml
@@ -17,12 +17,12 @@
     %tbody
       %tr
         %td
-        - 1.step(max_port-1, 2) do |port|
+        - (@port_start).step(max_port-1, 2) do |port|
           =render :partial => 'dense', :locals => { :switch=> switch, :sw_details=>sw_details, :port=>port, :max_port=>max_port } 
         %td
       %tr
         %td
-        - 2.step(max_port, 2) do |port|
+        - (@port_start+1).step(max_port, 2) do |port|
           =render :partial => 'dense', :locals => { :switch=> switch, :sw_details=>sw_details, :port=>port, :max_port=>max_port } 
         %td
 
@@ -36,12 +36,12 @@
     %tbody
       %tr
         %td
-        - 1.step(23, 2) do |port|
+        - (@port_start).step((@port_start+22), 2) do |port|
           =render :partial => 'switch', :locals => { :switch=> switch, :sw_details=>sw_details, :port=>port } 
         %td
       %tr
         %td
-        - 2.step(24, 2) do |port|
+        - (@port_start+1).step((@port_start+23), 2) do |port|
           =render :partial => 'switch', :locals => { :switch=> switch, :sw_details=>sw_details, :port=>port } 
         %td
   -if max_port>24
@@ -55,12 +55,12 @@
       %tbody
         %tr
           %td
-          - 25.step(max_port-1, 2) do |port|
+          - (@port_start+24).step(max_port-1, 2) do |port|
             =render :partial => 'switch', :locals => { :switch=> switch, :sw_details=>sw_details, :port=>port } 
           %td
         %tr
           %td
-          - 26.step(max_port, 2) do |port|
+          - (@port_start+25).step(max_port, 2) do |port|
             =render :partial => 'switch', :locals => { :switch=> switch, :sw_details=>sw_details, :port=>port } 
           %td
 


### PR DESCRIPTION
This small change allows the switch view to correctly
render switches that start at port number 0

 .../app/controllers/network_controller.rb          |    4 +++-
 .../app/views/network/switch.html.haml             |   12 ++++++------
 2 files changed, 9 insertions(+), 7 deletions(-)
