### PR TITLE
Added conduit related network models [1/1]

### DIFF
--- a/crowbar_framework/app/models/bus.rb
+++ b/crowbar_framework/app/models/bus.rb
@@ -1,0 +1,22 @@
+# Copyright 2012, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Bus < ActiveRecord::Base
+  belongs_to :bus_map, :inverse_of => :buses
+
+  attr_accessible :designator, :order
+
+  validates :order, :presence => true, :numericality => { :only_integer => true }
+  validates :designator, :presence => true
+end

--- a/crowbar_framework/app/models/bus_map.rb
+++ b/crowbar_framework/app/models/bus_map.rb
@@ -1,0 +1,23 @@
+# Copyright 2012, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class BusMap < ActiveRecord::Base
+  has_many :buses, :dependent => :destroy
+  belongs_to :interface_map, :inverse_of => :bus_maps
+
+  attr_accessible :pattern
+
+  validates :pattern, :presence => true
+  validates :buses, :presence => true
+end

--- a/crowbar_framework/app/models/interface_map.rb
+++ b/crowbar_framework/app/models/interface_map.rb
@@ -1,0 +1,19 @@
+# Copyright 2012, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class InterfaceMap < ActiveRecord::Base
+  has_many :bus_maps, :dependent => :destroy
+
+  validates :bus_maps, :presence => true
+end

--- a/crowbar_framework/db/migrate/20120914175602_create_buses.rb
+++ b/crowbar_framework/db/migrate/20120914175602_create_buses.rb
@@ -1,0 +1,11 @@
+class CreateBuses < ActiveRecord::Migration
+  def change
+    create_table :buses do |t|
+      t.integer :order
+      t.string :designator
+
+      t.references :bus_map
+      t.timestamps
+    end
+  end
+end

--- a/crowbar_framework/db/migrate/20120914175721_create_bus_maps.rb
+++ b/crowbar_framework/db/migrate/20120914175721_create_bus_maps.rb
@@ -1,0 +1,10 @@
+class CreateBusMaps < ActiveRecord::Migration
+  def change
+    create_table :bus_maps do |t|
+      t.string :pattern
+
+      t.references :interface_map
+      t.timestamps
+    end
+  end
+end

--- a/crowbar_framework/db/migrate/20120914175733_create_interface_maps.rb
+++ b/crowbar_framework/db/migrate/20120914175733_create_interface_maps.rb
@@ -1,0 +1,8 @@
+class CreateInterfaceMaps < ActiveRecord::Migration
+  def change
+    create_table :interface_maps do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/crowbar_framework/test/unit/bus_map_model_test.rb
+++ b/crowbar_framework/test/unit/bus_map_model_test.rb
@@ -1,0 +1,69 @@
+# Copyright 2012, Dell 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+
+require 'test_helper'
+ 
+class BusMapModelTest < ActiveSupport::TestCase
+  # Test successful creation
+  test "BusMap creation: success" do
+    create_a_bus_map()
+  end
+
+
+  # Test creation failure due to missing pattern
+  test "BusMap creation: failure due to missing pattern" do
+    assert_raise ActiveRecord::RecordInvalid do
+      bus_map = BusMap.new()
+      bus_map.buses << create_a_bus()
+      bus_map.save!
+    end
+  end
+
+
+  # Test creation failure due to missing bus
+  test "BusMap creation: failure due to missing bus" do
+    assert_raise ActiveRecord::RecordInvalid do
+      bus_map = BusMap.new( :pattern => "PowerEdge C2100")
+      bus_map.save!
+    end
+  end
+
+
+  # Test deletion cascade to Buses
+  test "BusMap deletion: cascade" do
+    bus_map = create_a_bus_map()
+    bus_id = bus_map.buses[0]
+    bus_map.destroy
+
+    assert_raise ActiveRecord::RecordNotFound do
+      Bus.find(bus_id)
+    end
+  end
+
+
+  private
+  def create_a_bus_map
+    bus_map = BusMap.new( :pattern => "PowerEdge C2100")
+    bus_map.buses << create_a_bus()
+    bus_map.save!
+
+    assert_not_nil bus_map
+    bus_map
+  end
+
+
+  def create_a_bus
+    Bus.new( :order => 1, :designator => "0000:00/0000:00:1c" )
+  end
+end

--- a/crowbar_framework/test/unit/bus_model_test.rb
+++ b/crowbar_framework/test/unit/bus_model_test.rb
@@ -1,0 +1,54 @@
+# Copyright 2012, Dell 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+
+require 'test_helper'
+ 
+class BusModelTest < ActiveSupport::TestCase
+  # Test successful creation
+  test "Bus creation: success" do
+    create_a_bus()
+  end
+
+
+  # Creation failure: non-existent order
+  test "Bus creation: failure due to non-existent order" do
+    assert_raise ActiveRecord::RecordInvalid do
+      Bus.create!( :designator => "0000:00/0000:00:1c" )
+    end
+  end
+
+
+  # Creation failure: non-numeric order
+  test "Bus creation: failure due to non-numeric order" do
+    assert_raise ActiveRecord::RecordInvalid do
+      Bus.create!( :order => "fred", :designator => "0000:00/0000:00:1c" )
+    end
+  end
+
+
+  # Creation failure: non-existent designator
+  test "Bus creation: failure due to non-existent designator" do
+    assert_raise ActiveRecord::RecordInvalid do
+      Bus.create!( :order => "fred" )
+    end
+  end
+
+
+  private
+  def create_a_bus
+    bus = Bus.create!( :order => 1, :designator => "0000:00/0000:00:1c" )
+    assert_not_nil bus
+    bus
+  end
+end

--- a/crowbar_framework/test/unit/interface_map_model_test.rb
+++ b/crowbar_framework/test/unit/interface_map_model_test.rb
@@ -1,0 +1,66 @@
+# Copyright 2012, Dell 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+
+require 'test_helper'
+ 
+class InterfaceMapModelTest < ActiveSupport::TestCase
+  # Test successful creation
+  test "InterfaceMap creation: success" do
+    create_an_interface_map()
+  end
+
+
+  # Test creation failure due to missing BusMap
+  test "IntefaceMap creation: failure due to missing BusMap" do
+    assert_raise ActiveRecord::RecordInvalid do
+      InterfaceMap.create!()
+    end
+  end
+
+
+  # Test deletion cascade to BusMaps
+  test "IntefaceMap deletion: cascade" do
+    interface_map = create_an_interface_map()
+    bus_map_id = interface_map.bus_maps[0]
+    interface_map.destroy
+
+    assert_raise ActiveRecord::RecordNotFound do
+      BusMap.find(bus_map_id)
+    end
+  end
+
+
+  private
+  def create_an_interface_map
+    interface_map = InterfaceMap.new()
+    interface_map.bus_maps << create_a_bus_map()
+    assert_not_nil interface_map
+    interface_map
+  end
+
+
+  def create_a_bus_map
+    bus_map = BusMap.new( :pattern => "PowerEdge C2100")
+    bus_map.buses << create_a_bus()
+    bus_map.save!
+
+    assert_not_nil bus_map
+    bus_map
+  end
+
+
+  def create_a_bus
+    Bus.new( :order => 1, :designator => "0000:00/0000:00:1c" )
+  end
+end


### PR DESCRIPTION
Added conduit related network models and their associated model unit tests.

 crowbar_framework/app/models/bus.rb                |   22 ++++++
 crowbar_framework/app/models/bus_map.rb            |   23 +++++++
 crowbar_framework/app/models/interface_map.rb      |   19 ++++++
 .../db/migrate/20120914175602_create_buses.rb      |   11 +++
 .../db/migrate/20120914175721_create_bus_maps.rb   |   10 +++
 .../20120914175733_create_interface_maps.rb        |    8 ++
 crowbar_framework/test/unit/bus_map_model_test.rb  |   69 ++++++++++++++++++++
 crowbar_framework/test/unit/bus_model_test.rb      |   54 +++++++++++++++
 .../test/unit/interface_map_model_test.rb          |   66 +++++++++++++++++++
 9 files changed, 282 insertions(+), 0 deletions(-)
