### PR TITLE
Add Redhat 6.2 support for nic tuning. [1/1]

### DIFF
--- a/chef/cookbooks/network/recipes/fast_nics_tune.rb
+++ b/chef/cookbooks/network/recipes/fast_nics_tune.rb
@@ -16,21 +16,28 @@
 # check if there are any 1g/10g interfaces detected.
 detected = Barclamp::Inventory.get_detected_intfs(node)
 log "detected interfaces: #{detected.inspect}"
+tuning_location='/etc/sysctl.d/20-10gbe.conf'
 tune = detected.any?{ |intf_name, intf| intf[:speeds].join.index('g') }
 
-begin 
+begin
   log "Applying 10gbe system tuning values" do
     level    :info
   end
-  template "sysctl-10gbe" do 
-    path    "/etc/sysctl.d/20-10gbe.conf"
+
+  # Make sure we have an /etc/sysctl.d path on Redhat 6.2
+  directory "/etc/sysctl.d" do
+    mode "755"
+  end
+
+  template "sysctl-10gbe" do
+    path    tuning_location
     source  "sysctl_10gbe.conf.erb"
     mode    "0644"
   end
-  
+
   # if we just created or modified the params, reload things
-  bash "reload sysctl" do 
-    code "/sbin/sysctl -p"
+  bash "reload sysctl" do
+    code "/sbin/sysctl -e -p #{tuning_location}"
     action :nothing
     subscribes :run, resources(:template=> "sysctl-10gbe"), :delayed
   end


### PR DESCRIPTION
Adds redhat6.2 and higher support for tuning fast nics.

 chef/cookbooks/network/recipes/fast_nics_tune.rb |   19 +++++++++++++------
 1 file changed, 13 insertions(+), 6 deletions(-)
