### PR TITLE
Read new network json & instanciate models [1/1]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-network-new.json
+++ b/chef/data_bags/crowbar/bc-template-network-new.json
@@ -106,10 +106,6 @@
                 }
               ],
               "conduit_actions": [
-                {
-                  "MapInterface": {
-                  }
-                }
               ]
             },
             {
@@ -132,10 +128,6 @@
                 }
               ],
               "conduit_actions": [
-                {
-                  "MapInterface": {
-                  }
-                }
               ]
             },
             {
@@ -155,10 +147,6 @@
                 }
               ],
               "conduit_actions": [
-                {
-                  "MapInterface": {
-                  }
-                }
               ]
             }
           ]
@@ -211,10 +199,6 @@
                 }
               ],
               "conduit_actions": [
-                {
-                  "MapInterface": {
-                  }
-                }
               ]
             },
             {
@@ -237,10 +221,6 @@
                 }
               ],
               "conduit_actions": [
-                {
-                  "MapInterface": {
-                  }
-                }
               ]
             },
             {
@@ -260,10 +240,6 @@
                 }
               ],
               "conduit_actions": [
-                {
-                  "MapInterface": {
-                  }
-                }
               ]
             }
           ]
@@ -316,10 +292,6 @@
                 }
               ],
               "conduit_actions": [
-                {
-                  "MapInterface": {
-                  }
-                }
               ]
             },
             {
@@ -342,10 +314,6 @@
                 }
               ],
               "conduit_actions": [
-                {
-                  "MapInterface": {
-                  }
-                }
               ]
             },
             {
@@ -365,10 +333,6 @@
                 }
               ],
               "conduit_actions": [
-                {
-                  "MapInterface": {
-                  }
-                }
               ]
             }
           ]
@@ -376,13 +340,11 @@
       ],
       "networks": {
         "bmc": {
-          "conduit": "bmc",
           "vlan": 100,
           "use_vlan": false,
           "add_bridge": false,
-          "subnet": "192.168.124.0",
-          "netmask": "255.255.255.0",
-          "broadcast": "192.168.124.255",
+          "subnet": "192.168.124.0/24",
+          "dhcp_enabled": false,
           "ranges": {
             "host": { "start": "192.168.124.162", "end": "192.168.124.240" }
           }
@@ -392,9 +354,8 @@
           "vlan": 100,
           "use_vlan": true,
           "add_bridge": false,
-          "subnet": "192.168.124.0",
-          "netmask": "255.255.255.0",
-          "broadcast": "192.168.124.255",
+          "subnet": "192.168.124.0/24",
+          "dhcp_enabled": false,
           "ranges": {
             "host": { "start": "192.168.124.161", "end": "192.168.124.161" }
           }
@@ -404,9 +365,8 @@
           "vlan": 100,
           "use_vlan": false,
           "add_bridge": false,
-          "subnet": "192.168.124.0",
-          "netmask": "255.255.255.0",
-          "broadcast": "192.168.124.255",
+          "subnet": "192.168.124.0/24",
+          "dhcp_enabled": false,
           "router": "192.168.124.1",
           "router_pref": 10, 
           "ranges": {

--- a/chef/data_bags/crowbar/bc-template-network-new.schema
+++ b/chef/data_bags/crowbar/bc-template-network-new.schema
@@ -87,11 +87,11 @@
                           "required": true,
                           "sequence": [ {
                             "type": "map",
-                            "required": true,
+                            "required": false,
                             "mapping": {
                               = : {
                                 "type": "map",
-                                "required": true,
+                                "required": false,
                                 "mapping": {
                                   = : { "type": "str", "required": true }
                                 }
@@ -113,13 +113,12 @@
                   "type": "map",
                   "required": true,
                   "mapping": {
-                    "conduit": { "type": "str", "required": true },
+                    "conduit": { "type": "str", "required": false },
                     "vlan": { "type": "int", "required": true },
                     "use_vlan": { "type": "bool", "required": true },
                     "add_bridge": { "type": "bool", "required": true },
                     "subnet": { "type": "str", "required": true, "name": "IpAddress" },
-                    "netmask": { "type": "str", "required": true, "name": "IpAddress" },
-                    "broadcast": { "type": "str", "required": true, "name": "IpAddress" },
+                    "dhcp_enabled": { "type": "bool", "required": true },
                     "router": { "type": "str", "name": "IpAddress" },
                     "router_pref": { "type": "int", "required": false },
                     "ranges": {

--- a/crowbar_framework/app/controllers/network_controller.rb
+++ b/crowbar_framework/app/controllers/network_controller.rb
@@ -53,7 +53,7 @@ class NetworkController < BarclampController
     name = params[:name]
     conduit_id = params[:conduit_id]
     subnet = params[:subnet]
-    dhcp_enabled = params[:dhcp_enabled]
+    dhcp_enabled = to_bool( params[:dhcp_enabled] )
     ip_ranges_json = params[:ip_ranges]
     if !ip_ranges_json.nil?
       ip_ranges = JSON.parse(ip_ranges_json)
@@ -77,7 +77,7 @@ class NetworkController < BarclampController
     id = params[:id]
     conduit_id = params[:conduit_id]
     subnet = params[:subnet]
-    dhcp_enabled = params[:dhcp_enabled]
+    dhcp_enabled = to_bool( params[:dhcp_enabled] )
     ip_ranges_json = params[:ip_ranges]
     if !ip_ranges_json.nil?
       ip_ranges = JSON.parse(ip_ranges_json)
@@ -228,6 +228,11 @@ class NetworkController < BarclampController
   end
     
   private 
+  def to_bool(value)
+    return true if value == true || value =~ /^true|t$/i
+    return false if value == false || value =~ /^false|f$/i
+    raise ArgumentError.new("Invalid boolean value")
+  end    
   
   def node_vlans(node)
     nv = {}

--- a/crowbar_framework/app/models/conduit_rule.rb
+++ b/crowbar_framework/app/models/conduit_rule.rb
@@ -18,7 +18,5 @@ class ConduitRule < ActiveRecord::Base
   has_many :conduit_actions, :dependent => :destroy
   belongs_to :conduit, :inverse_of => :conduit_rules
 
-  validates :conduit_filters, :presence => true
   validates :interface_selectors, :presence => true
-  validates :conduit_actions, :presence => true
 end

--- a/crowbar_framework/app/models/network.rb
+++ b/crowbar_framework/app/models/network.rb
@@ -22,8 +22,7 @@ class Network < ActiveRecord::Base
   attr_accessible :name, :dhcp_enabled
 
   validates :name, :presence => true, :uniqueness => true
-  validates :dhcp_enabled, :presence => true, :inclusion => { :in => ["true", "false"] }
+  validates :dhcp_enabled, :inclusion => { :in => [true, false] }
   validates :subnet, :presence => true
-  validates :conduit, :presence => true
   validates :ip_ranges, :presence => true
 end

--- a/crowbar_framework/app/models/network_mode_filter.rb
+++ b/crowbar_framework/app/models/network_mode_filter.rb
@@ -13,4 +13,14 @@
 # limitations under the License.
 
 class NetworkModeFilter < ConduitFilter
+  def initialize()
+    super()
+    self.attr="network_mode"
+    self.comparitor="="
+  end
+
+
+  def network_mode=( mode )
+    self.value="mode"
+  end
 end

--- a/crowbar_framework/app/models/select_by_index.rb
+++ b/crowbar_framework/app/models/select_by_index.rb
@@ -13,4 +13,8 @@
 # limitations under the License.
 
 class SelectByIndex < InterfaceSelector
+  def initialize()
+    super()
+    self.comparitor="="
+  end
 end

--- a/crowbar_framework/app/models/select_by_speed.rb
+++ b/crowbar_framework/app/models/select_by_speed.rb
@@ -13,4 +13,8 @@
 # limitations under the License.
 
 class SelectBySpeed < InterfaceSelector
+  def initialize()
+    super()
+    self.comparitor="="
+  end
 end

--- a/crowbar_framework/db/migrate/20120730175122_create_networks.rb
+++ b/crowbar_framework/db/migrate/20120730175122_create_networks.rb
@@ -16,7 +16,7 @@ class CreateNetworks < ActiveRecord::Migration
   def change
     create_table :networks do |t|
       t.string :name
-      t.binary :dhcp_enabled
+      t.boolean :dhcp_enabled
       t.references :conduit
 
       t.timestamps

--- a/crowbar_framework/test/network_test_helper.rb
+++ b/crowbar_framework/test/network_test_helper.rb
@@ -17,7 +17,7 @@ class NetworkTestHelper
   def self.create_a_network
     network = Network.new
     network.name = "fred"
-    network.dhcp_enabled = "true"
+    network.dhcp_enabled = true
     network.subnet = IpAddress.create!( :cidr => "192.168.130.11/24" )
     network.conduit = create_a_conduit()
     network.router = create_a_router()

--- a/crowbar_framework/test/unit/conduit_rule_test.rb
+++ b/crowbar_framework/test/unit/conduit_rule_test.rb
@@ -24,34 +24,6 @@ class ConduitRuleTest < ActiveSupport::TestCase
   end
 
 
-  # Test creation failure due to missing conduit filter
-  test "ConduitRule creation: failure due to missing conduit filter" do
-    assert_raise ActiveRecord::RecordInvalid do
-      sbs = SelectBySpeed.new()
-      sbs.comparitor = "="
-      sbs.value = "1g"
-      rule = ConduitRule.new()
-      rule.conduit_actions << NetworkTestHelper.create_a_conduit_action()
-      rule.interface_selectors << sbs
-      rule.save!
-    end
-  end
-
-
-  # Test creation failure due to missing conduit action
-  test "ConduitRule creation: failure due to missing conduit action" do
-    assert_raise ActiveRecord::RecordInvalid do
-      sbs = SelectBySpeed.new()
-      sbs.comparitor = "="
-      sbs.value = "1g"
-      rule = ConduitRule.new()
-      rule.conduit_filters << NetworkTestHelper.create_a_conduit_filter()
-      rule.interface_selectors << sbs
-      rule.save!
-    end
-  end
-
-
   # Test creation failure due to missing interface selectors
   test "ConduitRule creation: failure due to missing interface selectors" do
     assert_raise ActiveRecord::RecordInvalid do

--- a/crowbar_framework/test/unit/network_model_test.rb
+++ b/crowbar_framework/test/unit/network_model_test.rb
@@ -65,7 +65,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   test "Network creation: failure due to missing name" do
     assert_raise ActiveRecord::RecordInvalid do
       network = Network.new
-      network.dhcp_enabled = "true"
+      network.dhcp_enabled = true
       network.subnet = IpAddress.create!( :cidr => "192.168.130.11/24" )
       network.conduit = Conduit.create!( :name => "intf0" )
       network.ip_ranges << NetworkTestHelper.create_an_ip_range()
@@ -106,21 +106,8 @@ class NetworkModelTest < ActiveSupport::TestCase
     assert_raise ActiveRecord::RecordInvalid do
       network = Network.new
       network.name = "fred"
-      network.dhcp_enabled = "false"
+      network.dhcp_enabled = false
       network.conduit = Conduit.create!( :name => "intf0" )
-      network.ip_ranges << NetworkTestHelper.create_an_ip_range()
-      network.save!
-    end
-  end
-
-
-  # conduit does not exist
-  test "Network creation: failure due to missing conduit" do
-    assert_raise ActiveRecord::RecordInvalid do
-      network = Network.new
-      network.name = "fred"
-      network.dhcp_enabled = "false"
-      network.subnet = IpAddress.create!( :cidr => "192.168.130.11/24" )
       network.ip_ranges << NetworkTestHelper.create_an_ip_range()
       network.save!
     end
@@ -132,7 +119,7 @@ class NetworkModelTest < ActiveSupport::TestCase
     assert_raise ActiveRecord::RecordInvalid do
       network = Network.new
       network.name = "fred"
-      network.dhcp_enabled = "false"
+      network.dhcp_enabled = false
       network.subnet = IpAddress.create!( :cidr => "192.168.130.11/24" )
       network.conduit = Conduit.create!( :name => "intf0" )
       network.save!

--- a/crowbar_framework/test/unit/network_service_test.rb
+++ b/crowbar_framework/test/unit/network_service_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License. 
 # 
 require 'test_helper'
+require 'network_service'
  
 class NetworkServiceTest < ActiveSupport::TestCase
 
@@ -30,7 +31,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
         "public2",
         "intf0",
         "192.168.122.0/24",
-        "false",
+        false,
         JSON.parse('{ "host": { "start": "192.168.122.2", "end": "192.168.122.49" }, "dhcp": { "start": "192.168.122.50", "end": "192.168.122.127" }}'),
         nil,
         "192.168.122.1" )
@@ -46,7 +47,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
         "public3",
         "intf0",
         "192.168.122.0/24",
-        "false",
+        false,
         JSON.parse('{ "host": { "start": "192.168.122.2", "end": "192.168.122.49" }, "dhcp": { "start": "192.168.122.50", "end": "192.168.122.127" }}'),
         "5",
         nil )
@@ -62,7 +63,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
         "public4",
         "intf0",
         "192.168.122.0/24",
-        "false",
+        false,
         nil,
         5,
         "192.168.122.1" )
@@ -117,7 +118,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
         net_name,
         "intf0",
         "192.168.122.0/24",
-        "false",
+        false,
         JSON.parse('{ "host": { "start": "192.168.122.2", "end": "192.168.122.49" }, "dhcp": { "start": "192.168.122.50", "end": "192.168.122.127" }, "admin": { "start": "192.168.122.128", "end": "192.168.122.149" }}'),
         5,
         "192.168.122.1" )
@@ -138,7 +139,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
         net_name,
         "intf0",
         "192.168.122.0/24",
-        "false",
+        false,
         JSON.parse('{ "host": { "start": "192.168.122.2", "end": "192.168.122.49" }}'),
         5,
         "192.168.122.1" )
@@ -159,7 +160,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
         net_name,
         "intf0",
         "192.168.122.0/24",
-        "false",
+        false,
         '',
         5,
         "192.168.122.1" )
@@ -178,7 +179,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
         net_name,
         "intf0",
         "192.168.122.0/24",
-        "false",
+        false,
         JSON.parse('{ "host": { "end": "192.168.122.49" }, "dhcp": { "start": "192.168.122.50", "end": "192.168.122.127" }}'),
         5,
         "192.168.122.1" )
@@ -197,7 +198,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
         net_name,
         "intf0",
         "192.168.122.0/24",
-        "false",
+        false,
         JSON.parse('{ "host": { "start": "192.168.122.2" }, "dhcp": { "start": "192.168.122.50", "end": "192.168.122.127" }}'),
         5,
         "192.168.122.1" )
@@ -216,7 +217,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
         net_name,
         "intf0",
         "192.168.122.0/24",
-        "false",
+        false,
         JSON.parse('{ "host": { "start": "192.168.122.2", "end": "192.168.122.49" }, "dhcp": { "start": "192.168.122.50", "end": "192.168.122.127" }}'),
         nil,
         "192.168.122.1" )
@@ -235,7 +236,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
         net_name,
         "intf0",
         "192.168.122.0/24",
-        "false",
+        false,
         JSON.parse('{ "host": { "start": "192.168.122.2", "end": "192.168.122.49" }, "dhcp": { "start": "192.168.122.50", "end": "192.168.122.127" }}'),
         "5",
         nil )
@@ -265,6 +266,20 @@ class NetworkServiceTest < ActiveSupport::TestCase
   end
 
 
+  # Test population of network defaults
+  test "network_defaults_populate" do
+    template_file = "barclamps/templates/bc-template-network-new.json"
+    json = JSON::load File.open(template_file, 'r')
+
+    network_service = NetworkService.new(Rails.logger)
+    network_service.populate_network_defaults( json["attributes"]["network"] )
+
+    assert Conduit.count > 0, "There are no Conduits"
+    assert InterfaceMap.count == 1, "There is no InterfaceMap"
+    assert Network.count > 0, "There are no Networks"
+  end
+
+
   private
   # Create a Network
   def create_a_network(net_service, name)
@@ -276,7 +291,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
         name,
         "intf0",
         "192.168.122.0/24",
-        "false",
+        false,
         JSON.parse('{ "host": { "start": "192.168.122.2", "end": "192.168.122.49" }, "dhcp": { "start": "192.168.122.50", "end": "192.168.122.127" }}'),
         "5",
         "192.168.122.1" )


### PR DESCRIPTION
Added code to read the new network json and instantiate network models
Correct Network.dhcp_enabled data type
Updated unit tests based on discussions

 .../data_bags/crowbar/bc-template-network-new.json |   52 +-------
 .../crowbar/bc-template-network-new.schema         |    9 +-
 .../app/controllers/network_controller.rb          |    9 +-
 crowbar_framework/app/models/conduit_rule.rb       |    2 -
 crowbar_framework/app/models/network.rb            |    3 +-
 .../app/models/network_mode_filter.rb              |   10 ++
 crowbar_framework/app/models/network_service.rb    |  136 ++++++++++++++++++++
 crowbar_framework/app/models/select_by_index.rb    |    4 +
 crowbar_framework/app/models/select_by_speed.rb    |    4 +
 .../db/migrate/20120730175122_create_networks.rb   |    2 +-
 crowbar_framework/test/network_test_helper.rb      |    2 +-
 crowbar_framework/test/unit/conduit_rule_test.rb   |   28 ----
 crowbar_framework/test/unit/network_model_test.rb  |   19 +---
 .../test/unit/network_service_test.rb              |   37 ++++--
 14 files changed, 203 insertions(+), 114 deletions(-)
