### PR TITLE
Better fix for new network json [2/2]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-network-new.schema
+++ b/chef/data_bags/crowbar/bc-template-network-new.schema
@@ -117,7 +117,7 @@
                     "vlan": { "type": "int", "required": true },
                     "use_vlan": { "type": "bool", "required": true },
                     "add_bridge": { "type": "bool", "required": true },
-                    "subnet": { "type": "str", "required": true },
+                    "subnet": { "type": "str", "required": true, "name": "CidrIpAddress" },
                     "dhcp_enabled": { "type": "bool", "required": true },
                     "router": { "type": "str", "name": "IpAddress" },
                     "router_pref": { "type": "int", "required": false },


### PR DESCRIPTION
This change adds a new CidrIpAddress type to the kwalify schema for jsons.
The new network json uses this type for validation on subnets.

 .../crowbar/bc-template-network-new.schema         |    2 +-
 1 files changed, 1 insertions(+), 1 deletions(-)
