### PR TITLE
Network config creation on network barclamp instantiation [2/2]

### DIFF
--- a/crowbar_framework/app/models/conduit.rb
+++ b/crowbar_framework/app/models/conduit.rb
@@ -15,6 +15,7 @@
 class Conduit < ActiveRecord::Base
   has_many :networks, :inverse_of => :conduit, :dependent => :nullify
   has_many :conduit_rules, :dependent => :destroy
+  belongs_to :proposal, :inverse_of => :conduits
 
   attr_accessible :name
 

--- a/crowbar_framework/app/models/interface_map.rb
+++ b/crowbar_framework/app/models/interface_map.rb
@@ -14,6 +14,7 @@
 
 class InterfaceMap < ActiveRecord::Base
   has_many :bus_maps, :dependent => :destroy
+  belongs_to :proposal, :inverse_of => :interface_map
 
   validates :bus_maps, :presence => true
 end

--- a/crowbar_framework/app/models/network.rb
+++ b/crowbar_framework/app/models/network.rb
@@ -18,6 +18,7 @@ class Network < ActiveRecord::Base
   belongs_to :conduit, :inverse_of => :networks
   has_one :router, :inverse_of => :network, :dependent => :destroy
   has_many :ip_ranges, :dependent => :destroy
+  belongs_to :proposal, :inverse_of => :networks
 
   attr_accessible :name, :dhcp_enabled
 

--- a/crowbar_framework/db/migrate/20120730175122_create_networks.rb
+++ b/crowbar_framework/db/migrate/20120730175122_create_networks.rb
@@ -18,6 +18,7 @@ class CreateNetworks < ActiveRecord::Migration
       t.string :name
       t.boolean :dhcp_enabled
       t.references :conduit
+      t.references :proposal
 
       t.timestamps
     end

--- a/crowbar_framework/db/migrate/20120821194639_create_conduits.rb
+++ b/crowbar_framework/db/migrate/20120821194639_create_conduits.rb
@@ -16,6 +16,7 @@ class CreateConduits < ActiveRecord::Migration
   def change
     create_table :conduits do |t|
       t.string :name
+      t.references :proposal
 
       t.timestamps
     end

--- a/crowbar_framework/db/migrate/20120914175733_create_interface_maps.rb
+++ b/crowbar_framework/db/migrate/20120914175733_create_interface_maps.rb
@@ -15,6 +15,7 @@
 class CreateInterfaceMaps < ActiveRecord::Migration
   def change
     create_table :interface_maps do |t|
+      t.references :proposal
 
       t.timestamps
     end

--- a/crowbar_framework/test/unit/network_service_test.rb
+++ b/crowbar_framework/test/unit/network_service_test.rb
@@ -272,7 +272,7 @@ class NetworkServiceTest < ActiveSupport::TestCase
     json = JSON::load File.open(template_file, 'r')
 
     network_service = NetworkService.new(Rails.logger)
-    network_service.populate_network_defaults( json["attributes"]["network"] )
+    network_service.populate_network_defaults( json["attributes"]["network"], nil )
 
     assert Conduit.count > 0, "There are no Conduits"
     assert InterfaceMap.count == 1, "There is no InterfaceMap"


### PR DESCRIPTION
This pull request adds in network model object creation on network barclamp instantiation.
A relationship was added between the top level network objects and the network proposal.

 crowbar_framework/app/models/conduit.rb            |    1 +
 crowbar_framework/app/models/interface_map.rb      |    1 +
 crowbar_framework/app/models/network.rb            |    1 +
 crowbar_framework/app/models/network_service.rb    |   47 ++++++++++----------
 .../db/migrate/20120730175122_create_networks.rb   |    1 +
 .../db/migrate/20120821194639_create_conduits.rb   |    1 +
 .../20120914175733_create_interface_maps.rb        |    1 +
 .../test/unit/network_service_test.rb              |    2 +-
 8 files changed, 31 insertions(+), 24 deletions(-)
