### PR TITLE
Make sure that we always sort by network name when setting up interfaces. [1/1]

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -175,9 +175,10 @@ def crowbar_interfaces()
     end
   }
   Chef::Log.info("will allow routers from #{net_pref}")
-  node["crowbar"]["network"].each do |netname, network|
+  node["crowbar"]["network"].keys.sort.each do |netname|
     next if netname == "bmc"
     allow_gw = (netname == net_pref)
+    network=node["crowbar"]["network"][netname]
 
     conduit = network["conduit"]
     ## get info about the network:


### PR DESCRIPTION
This should fix the bug that Nicholas is seeing on his Hadoop edgenodes.

 chef/cookbooks/network/recipes/default.rb |    3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 42631a46b117d6ef92a930a14b6e12a72726c8d3

Crowbar-Release: fred
