### PR TITLE
Unit test additions and clean-up to enable the mysql barclamp to be applied [2/3]

### DIFF
--- a/crowbar_framework/BDD/networks.erl
+++ b/crowbar_framework/BDD/networks.erl
@@ -11,7 +11,7 @@ g(Item) ->
   end.
 
 
-json(Name, Description, Order) ->
+json(Name, _Description, _Order) ->
   network_json(Name, "{" ++ ?IP_RANGE ++ "}").
 
 


### PR DESCRIPTION
In this pull request set, the following things are addressed:
1. Addition of a mostly complete unit test for the proposal_config model
2. Clean-up of warnings in the BDD code in both crowbar and network barclamps
3. Fix error/bug in keystone that keeps it from being created.

As a side effect of the unit test for proposal_config, there are lots of 
bugs fixed with the side effect that the mysql barclamp can be create and committed.

Keystone can be applied, but dependency checks fail.  More unit tests needed for that.

 crowbar_framework/BDD/networks.erl |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 56db139c1ebcc1e94094f4219193c0e4e205ec04

Crowbar-Release: development
