### PR TITLE
Unit test additions and clean-up to enable the mysql barclamp to be applied [2/4]

### DIFF
--- a/crowbar_framework/BDD/networks.erl
+++ b/crowbar_framework/BDD/networks.erl
@@ -11,7 +11,7 @@ g(Item) ->
   end.
 
 
-json(Name, Description, Order) ->
+json(Name, _Description, _Order) ->
   network_json(Name, "{" ++ ?IP_RANGE ++ "}").
 
 


### PR DESCRIPTION
In this pull request set, the following things are addressed:
1. Addition of a mostly complete unit test for the proposal_config model
2. Clean-up of warnings in the BDD code in both crowbar and network barclamps
3. Fix error/bug in keystone that keep it from being created.
4. Fix error/bug in glance that keep it from being created.
5. Fix/change update_proposal_status to operate on the proposal_config and not the active proposal.

As a side effect of the unit test for proposal_config, there are lots of
bugs fixed with the side effect that the mysql barclamp can be create and committed.

With the fix to keystone, glance, and the proposal update function, glance and keystone deploy.

 crowbar_framework/BDD/networks.erl |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: f9a4b0b232ba0d5c60bf89d5cf3cd43798dfe8a0

Crowbar-Release: development
