### PR TITLE
[Ruby 1.9] Fix broken ip_range unit tests

### DIFF
--- a/crowbar_framework/test/unit/ip_range_model_test.rb
+++ b/crowbar_framework/test/unit/ip_range_model_test.rb
@@ -75,9 +75,9 @@ class IpRangeModelTest < ActiveSupport::TestCase
     ip_range.destroy()
 
     ip_ranges = IpAddress.where( :start_ip_range_id => ip_range_id )
-    assert 0, ip_ranges.size
+    assert_equal 0, ip_ranges.size
 
     ip_ranges = IpAddress.where( :end_ip_range_id => ip_range_id )
-    assert 0, ip_ranges.size
+    assert_equal 0, ip_ranges.size
   end
 end


### PR DESCRIPTION
`assert` is incorrectly used here, since it just tests that the first
argument is `true`, which in Ruby means _any_ object (eg. 0, 1, "", [],
{}) except `false` and `nil`.

Ruby 1.9 is stricter here and checks that the second argument is a
`String` or `Proc`, thus uncovering the bug/typo. `assert_equal` should
be used here instead.
