### PR TITLE
allow creating the default crowbar proposal in the unit test env [1/1]

### DIFF
--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -22,7 +22,9 @@ class NetworkService < ServiceObject
 
     # TODO Remove the below HACK and uncomment the line above when we switch to the new network json
     # Start HACK
-    new_json = JSON.load File.open("/opt/dell/barclamps/network/chef/data_bags/crowbar/bc-template-network-new.json", "r")
+    # on admin, should result in:"/opt/dell/barclamps/network/chef/data_bags/crowbar/bc-template-network-new.json"
+    fp = File.join(Rails.root,"..","barclamps","network","chef","data_bags","crowbar","bc-template-network-new.json")
+    new_json = JSON.load File.open(fp, "r")
     attrs_config = new_json["attributes"]
     # End HACK
 


### PR DESCRIPTION
This change modifies hack to load the new default proposal relative to the rails root directory, so it works in the unit test environment too

 crowbar_framework/app/models/network_service.rb |    4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 225b7f536ac55cb9ef75c704a50999f331e1a1a3

Crowbar-Release: development
