### PR TITLE
attempt to fix reset issues on multi nic nodes

### DIFF
--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -241,6 +241,7 @@ class NetworkService < ServiceObject
 
       nets = node.crowbar["crowbar"]["network"].keys
       nets.each do |net|
+        next if net == "admin"
         ret, msg = self.deallocate_ip(inst, net, name)
         return [ ret, msg ] if ret != 200
       end


### PR DESCRIPTION
when reseting a node, keep the "admin" network ip allocation for the node.

this allows us to serve up it's address, pxe/uefi config, and have it retain it's name
