### PR TITLE
Barclamp View fix (Trello 73) [2/2]

### DIFF
--- a/BDD/features/networks.feature
+++ b/BDD/features/networks.feature
@@ -3,40 +3,40 @@ Feature: Networks
   wants to be able to list, show, create, edit, and delete networks
 
   Scenario: Update a network
-    Unless interactive
+    While interactive
     Given REST creates the {object:networks} "bdd_net"
     When the ip range "\"dhcp\":{\"start\":\"192.168.124.21\",\"end\":\"192.168.124.80\"}" is added to the network "bdd_net"
     Then the network is properly formatted
     Finally REST deletes the {object:networks} "bdd_net"
   
   Scenario: Create a network
-    Unless interactive
+    While interactive
     When REST creates the {object:networks} "bdd_net"
     Then the network is properly formatted
     Finally REST deletes the {object:networks} "bdd_net"
 
   Scenario: Show a network
-    Unless interactive
+    While interactive
     Given REST creates the {object:networks} "bdd_net"
     When REST requests the network "bdd_net"
     Then the network is properly formatted
     Finally REST deletes the {object:networks} "bdd_net"
 
   Scenario: Retrieve the list of networks
-    Unless interactive
+    While interactive
     Given REST creates the {object:networks} "bdd_net"
     When REST requests the list of networks
     Then the object id list is properly formatted
     Finally REST deletes the {object:networks} "bdd_net"
   
   Scenario: Delete a network
-    Unless interactive
+    While interactive
     Given REST creates the {object:networks} "bdd_net"
     When REST deletes the {object:networks} "bdd_net"
     Then there is not a network "bdd_net"
 
   Scenario: Allocate an IP to a node
-    Unless interactive
+    While interactive
     Given REST creates the {object:networks} "bdd_net"
       And there is a {object:node} "node.net.com"
     When an IP address is allocated to node "node.net.com" on {object:networks} "bdd_net" from range "host"
@@ -45,7 +45,7 @@ Feature: Networks
       And REST removes {object:node} "node.net.com"
 
   Scenario: Deallocate an IP from a node
-    Unless interactive
+    While interactive
     Given REST creates the {object:networks} "bdd_net"
       And there is a {object:node} "node.net.com"
       And an IP address is allocated to node "node.net.com" on {object:networks} "bdd_net" from range "host"


### PR DESCRIPTION
Related to Trello Card 73 https://trello.com/c/tgjZxwmi

In this pull, I changed the Barclamps view to use the new barclamp configuration models.

Since those modes were not complete, I had to (re)create the migrations for those models
and add the needed tests.

While I was in that part of the code, I saw a lot of places that we need to refactor
to move from proposals to configurations.  I tried to fix/strength/migrate where I
could do it with small touches.

I started to mark CB1 legacy code as "CB1 TODO" to make it easier to find.

We are straddling the old and new code bases - we're going to have to tear some of the
old stuff out really really soone.

PS: Minor fix to network barclamp to reflect new BDD testing logic.

 BDD/features/networks.feature |   14 +++++++-------
 1 file changed, 7 insertions(+), 7 deletions(-)

Crowbar-Pull-ID: a5cef33661485f12205db574632537726a51de3b

Crowbar-Release: development
