### PR TITLE
Ported get_conduits to CR 2.0. [2/2]

### DIFF
--- a/crowbar_framework/app/models/attrib_instance_bus_order.rb
+++ b/crowbar_framework/app/models/attrib_instance_bus_order.rb
@@ -30,7 +30,7 @@ class AttribInstanceBusOrder < AttribInstance
   
 
   def actual=(value)
-    raise "This attribute is read-only"
+    # Discard since this attribute is a facade over AR objects
   end
   
 

--- a/crowbar_framework/app/models/attrib_instance_ip_address.rb
+++ b/crowbar_framework/app/models/attrib_instance_ip_address.rb
@@ -30,7 +30,7 @@ class AttribInstanceIpAddress < AttribInstance
   
 
   def actual=(value)
-    raise "This attribute is read-only"
+    # Discard since this attribute is a facade over AR objects
   end
   
 

--- a/crowbar_framework/app/models/conduit.rb
+++ b/crowbar_framework/app/models/conduit.rb
@@ -1,4 +1,4 @@
-# Copyright 2012, Dell
+# Copyright 2013, Dell
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,4 +22,32 @@ class Conduit < ActiveRecord::Base
   validates_uniqueness_of :name, :presence => true, :scope => :proposal_id
   validates :conduit_rules, :presence => true
   validates :proposal, :presence => true
+
+
+  def self.get_conduit_rules(node)
+    conduit_rules = {}
+    # Loop thru each of the Conduits (intf0, intf1, etc)
+    Conduit.all.each do |conduit|
+      # Find the ConduitRule where...
+      conduit.conduit_rules.each do |conduit_rule|
+        # each of the supplied ConduitFilters match 
+        found_match=true
+        conduit_rule.conduit_filters.each do |conduit_filter|
+          if !conduit_filter.match(node)
+            found_match=false
+            break
+          end
+        end
+
+        # If the conduit filters for this ConduitRule did match, then...
+        if found_match
+          # This is the ConduitRule that we want, so put it in the hash
+          conduit_rules[conduit.name] = conduit_rule
+          break
+        end
+      end
+    end
+
+    conduit_rules
+  end
 end

--- a/crowbar_framework/app/models/conduit_filter.rb
+++ b/crowbar_framework/app/models/conduit_filter.rb
@@ -1,4 +1,4 @@
-# Copyright 2012, Dell
+# Copyright 2013, Dell
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,5 +17,8 @@ class ConduitFilter < ActiveRecord::Base
 
   attr_accessible :attr, :comparitor, :end_value, :start_value, :value
 
-  validates :comparitor, :presence => true
+
+  def match(node)
+    raise "Subclasses must implement match method!"
+  end
 end

--- a/crowbar_framework/app/models/interface_selector.rb
+++ b/crowbar_framework/app/models/interface_selector.rb
@@ -16,6 +16,4 @@ class InterfaceSelector < ActiveRecord::Base
   belongs_to :conduit_rule, :inverse_of => :interface_selectors
 
   attr_accessible :comparitor, :end_value, :start_value, :value
-
-  validates :comparitor, :presence => true
 end

--- a/crowbar_framework/app/models/network_mode_filter.rb
+++ b/crowbar_framework/app/models/network_mode_filter.rb
@@ -1,4 +1,4 @@
-# Copyright 2012, Dell
+# Copyright 2013, Dell
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,20 @@
 # limitations under the License.
 
 class NetworkModeFilter < ConduitFilter
-  def initialize()
-    super()
-    self.attr="network_mode"
-    self.comparitor="="
+  def network_mode=( mode )
+    self.value = mode
   end
 
 
-  def network_mode=( mode )
-    self.value="mode"
+  def match(node)
+    # TODO: Figure out the configured networking mode
+    # The below is an ugly hack to read in the configured network mode from
+    # the new network json
+    # Start HACK
+    new_json = NetworkService.read_new_network_json()
+    configured_teaming_mode = new_json["attributes"]["network"]["mode"]
+    # End HACK
+
+    value.casecmp(configured_teaming_mode) == 0
   end
 end

--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -18,17 +18,21 @@ class NetworkService < ServiceObject
   def apply_role_pre_chef_call(old_config, new_config, all_nodes)
     proposal = new_config.proposal
 
-    #attrs_config = JSON.parse( proposal.barclamp.template.current_config.config )
+    # TODO Remove the below HACK and add code the retrieves the new network
+    # json from the barclamp template
 
-    # TODO Remove the below HACK and uncomment the line above when we switch to the new network json
     # Start HACK
-    # on admin, should result in:"/opt/dell/barclamps/network/chef/data_bags/crowbar/bc-template-network-new.json"
-    fp = File.join(Rails.root,"..","barclamps","network","chef","data_bags","crowbar","bc-template-network-new.json")
-    new_json = JSON.load File.open(fp, "r")
+    new_json = read_new_network_json()
     attrs_config = new_json["attributes"]
     # End HACK
 
     populate_network_defaults( attrs_config["network"], proposal )
+  end
+
+
+  def self.read_new_network_json()
+    fp = File.join(Rails.root,"..","barclamps","network","chef","data_bags","crowbar","bc-template-network-new.json")
+    JSON.load File.open(fp, "r")
   end
 
 

--- a/crowbar_framework/app/models/node_attribute_filter.rb
+++ b/crowbar_framework/app/models/node_attribute_filter.rb
@@ -1,4 +1,4 @@
-# Copyright 2012, Dell
+# Copyright 2013, Dell
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,4 +13,12 @@
 # limitations under the License.
 
 class NodeAttributeFilter < ConduitFilter
+  def match(node)
+    attr_name = self.attr.split(".")
+    attrib = node.get_attrib(attr_name[0])
+
+    op_str = ".#{attr_name[1]}" if attr_name.length > 1
+
+    eval "self.value #{self.comparitor} attrib.value()#{op_str}"
+  end
 end

--- a/crowbar_framework/app/models/role_filter.rb
+++ b/crowbar_framework/app/models/role_filter.rb
@@ -1,4 +1,4 @@
-# Copyright 2012, Dell
+# Copyright 2013, Dell
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,5 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class SelectBySpeed < InterfaceSelector
+class RoleFilter < ConduitFilter
+  def pattern=(pat)
+    self.value = pat
+  end
+
+
+  def match(node)
+    found = false
+    roles = node.roles
+    roles.each do |role|
+      if role.name =~ /#{value}/
+        found = true
+        break
+      end
+    end
+
+    found
+  end
 end

--- a/crowbar_framework/app/models/select_by_index.rb
+++ b/crowbar_framework/app/models/select_by_index.rb
@@ -13,8 +13,4 @@
 # limitations under the License.
 
 class SelectByIndex < InterfaceSelector
-  def initialize()
-    super()
-    self.comparitor="="
-  end
 end

--- a/crowbar_framework/test/network_test_helper.rb
+++ b/crowbar_framework/test/network_test_helper.rb
@@ -146,4 +146,27 @@ class NetworkTestHelper
   end
 
 
+  def self.add_role(node, role_name)
+    role=Role.create!(:name=>role_name)
+    NodeRole.create!(:node_id => node.id, :role_id => role.id)
+  end
+
+
+  def self.create_node()
+    node = Node.create!(:name => "fred.flintstone.org")
+
+    nics = {}
+    eth0_parms = {}
+    eth0_parms["path"] = "0000:00/0000:00:11.0/0000:02:01:0"
+    eth0_parms["speeds"] = { "0" => "1g", "1" => "0g" }
+    nics["eth0"] = eth0_parms
+
+    eth1_parms = {}
+    eth1_parms["path"] = "0000:00/0000:00:11.0/0000:02:02:0"
+    eth1_parms["speeds"] = { "0" => "1g", "1" => "0g" }
+    nics["eth1"] = eth1_parms
+
+    node.set_attrib("nics", nics)
+    node
+  end
 end

--- a/crowbar_framework/test/unit/conduit_test.rb
+++ b/crowbar_framework/test/unit/conduit_test.rb
@@ -46,4 +46,154 @@ class ConduitTest < ActiveSupport::TestCase
       ConduitRule.find(conduit_rule_id)
     end
   end
+
+
+  # Test successful retrieval of conduit rules
+  test "Successful retrieval of conduit rules" do
+    # Create a node with a couple of Roles
+    node = Node.new(:name => "fred.flintstone.org")
+
+    NetworkTestHelper.add_role(node, "ganglia_client")
+    NetworkTestHelper.add_role(node, "dns_server")
+    node.save!
+    
+    # Set up intf0 conduit with 2 rules and 3 filters
+    # The idea is that the 1st rule will match for this conduit
+    conduit1 = Conduit.new(:name => "intf0")
+    conduit1.proposal = NetworkTestHelper.create_or_get_proposal()
+    conduit1.proposal.save!
+
+    rule1 = ConduitRule.new()
+    rule1.interface_selectors << SelectBySpeed.new(:comparitor => "=", :value => "1g")
+    conduit1.conduit_rules << rule1
+
+    nmf1 = NetworkModeFilter.new()
+    nmf1.network_mode = "single"
+    rule1.conduit_filters << nmf1
+    nmf1.save!
+
+    rf1 = RoleFilter.new()
+    rf1.pattern = "^ganglia_.+"
+    rule1.conduit_filters << rf1
+    rf1.save!
+
+    naf1 = NodeAttributeFilter.new()
+    naf1.attr = "nics.size"
+    naf1.comparitor = "=="
+    naf1.value = "2"
+    rule1.conduit_filters << naf1
+    naf1.save!
+
+    rule1.save!
+    
+    rule2 = ConduitRule.new()
+    rule2.interface_selectors << SelectBySpeed.new(:comparitor => "=", :value => "1g")
+    conduit1.conduit_rules << rule2
+
+    nmf2 = NetworkModeFilter.new()
+    nmf2.network_mode = "team"
+    rule2.conduit_filters << nmf2
+    nmf2.save!
+
+    rf2 = RoleFilter.new()
+    rf2.pattern = "^dns_.+"
+    rule2.conduit_filters << rf2
+    rf2.save!
+
+    naf2 = NodeAttributeFilter.new()
+    naf2.attr = "nics.size"
+    naf2.comparitor = "=="
+    naf2.value = "2"
+    rule2.conduit_filters << naf2
+    naf2.save!
+
+    rule2.save!
+
+    conduit1.save!
+
+    # Set up intf1 conduit with 2 rules and 3 filters
+    # The idea is that the 2nd rule will match for this conduit
+    conduit2 = Conduit.new(:name => "intf1")
+    conduit2.proposal = NetworkTestHelper.create_or_get_proposal()
+    conduit2.proposal.save!
+
+    rule3 = ConduitRule.new()
+    rule3.interface_selectors << SelectBySpeed.new(:comparitor => "=", :value => "1g")
+    conduit2.conduit_rules << rule3
+
+    nmf3 = NetworkModeFilter.new()
+    nmf3.network_mode = "single"
+    rule3.conduit_filters << nmf3
+    nmf3.save!
+
+    rf3 = RoleFilter.new()
+    rf3.pattern = "^dns_.+"
+    rule3.conduit_filters << rf3
+    rf3.save!
+
+    naf3 = NodeAttributeFilter.new()
+    naf3.attr = "nics.size"
+    naf3.comparitor = "=="
+    naf3.value = "42"
+    rule3.conduit_filters << naf3
+    naf3.save!
+
+    rule3.save!
+
+    rule4 = ConduitRule.new()
+    rule4.interface_selectors << SelectBySpeed.new(:comparitor => "=", :value => "1g")
+    conduit2.conduit_rules << rule4
+
+    nmf4 = NetworkModeFilter.new()
+    nmf4.network_mode = "single"
+    rule4.conduit_filters << nmf4
+    nmf4.save!
+
+    rf4 = RoleFilter.new()
+    rf4.pattern = "^ganglia_.+"
+    rule4.conduit_filters << rf4
+    rf4.save!
+
+    naf4 = NodeAttributeFilter.new()
+    naf4.attr = "nics.size"
+    naf4.comparitor = "=="
+    naf4.value = "2"
+    rule4.conduit_filters << naf4
+    naf4.save!
+
+    rule4.save!
+
+    conduit2.save!
+
+    # Set up intf2 conduit
+    # The idea is that no rules will match for this conduit
+    conduit3 = Conduit.new(:name => "intf2")
+    conduit3.proposal = NetworkTestHelper.create_or_get_proposal()
+    conduit3.proposal.save!
+
+    rule5 = ConduitRule.new()
+    rule5.interface_selectors << SelectBySpeed.new(:comparitor => "=", :value => "1g")
+    conduit3.conduit_rules << rule5
+
+    rf5 = RoleFilter.new()
+    rf5.pattern = "^coffee_maker_.+"
+    rule5.conduit_filters << rf5
+    rf5.save!
+
+    rule5.save!
+
+    conduit3.save!
+
+    # FINALLY run the test..
+    result = Conduit.get_conduit_rules(node)
+
+    result_conduit_rule1 = result["intf0"]
+    assert rule1, result_conduit_rule1
+
+    result_conduit_rule2 = result["intf1"]
+    assert rule4, result_conduit_rule2
+
+    result_conduit_rule3 = result["intf2"]
+    assert result_conduit_rule3.nil?
+  end
 end

--- a/crowbar_framework/test/unit/interface_selector_test.rb
+++ b/crowbar_framework/test/unit/interface_selector_test.rb
@@ -20,12 +20,4 @@ class InterfaceSelectorTest < ActiveSupport::TestCase
   test "InterfaceSelector creation: success" do
     InterfaceSelector.create!( :comparitor => "=", :value => "7" )
   end
-
-
-  # Test creation failure due to missing comparitor
-  test "InterfaceSelector creation: failure due to missing comparitor" do
-    assert_raise ActiveRecord::RecordInvalid do
-      InterfaceSelector.create!( :value => "7" )
-    end
-  end
 end

--- a/crowbar_framework/test/unit/network_mode_filter_test.rb
+++ b/crowbar_framework/test/unit/network_mode_filter_test.rb
@@ -1,0 +1,42 @@
+# Copyright 2013, Dell 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+# 
+require 'test_helper'
+ 
+class NetworkModeFilterTest < ActiveSupport::TestCase
+
+  # These tests assume that the default teaming mode in the network json
+  # is single
+  test "Test successful match" do
+    cf = NetworkModeFilter.new()
+    cf.network_mode = "single"
+    cf.save!
+
+    node = Node.create!(:name => "fred.flintstone.org")
+
+    result = cf.match(node)
+    assert result
+  end
+
+
+  test "Test unsuccessful match" do
+    cf = NetworkModeFilter.new()
+    cf.network_mode = "dual"
+
+    node = Node.create!(:name => "fred.flintstone.org")
+
+    result = cf.match(node)
+    assert !result
+  end
+end

--- a/crowbar_framework/test/unit/node_attribute_filter_test.rb
+++ b/crowbar_framework/test/unit/node_attribute_filter_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2012, Dell 
+# Copyright 2013, Dell 
 # 
 # Licensed under the Apache License, Version 2.0 (the "License"); 
 # you may not use this file except in compliance with the License. 
@@ -13,13 +13,32 @@
 # limitations under the License. 
 
 require 'test_helper'
-require 'network_test_helper'
  
-class ConduitFilterTest < ActiveSupport::TestCase
+class NodeAttributeFilterTest < ActiveSupport::TestCase
+  test "Test successful match" do
+    cf = NodeAttributeFilter.new()
+    cf.attr = "nics.size"
+    cf.comparitor = "=="
+    cf.value = 2
+    cf.save!
 
-  # Test successful creation
-  test "ConduitFilter creation: success" do
-    conduit_filter = NetworkTestHelper.create_a_conduit_filter()
-    conduit_filter.save!
+    node = NetworkTestHelper.create_node()
+
+    result = cf.match(node)
+    assert result
+  end
+
+
+  test "Test unsuccessful match" do
+    cf = NodeAttributeFilter.new()
+    cf.attr = "nics.size"
+    cf.comparitor = "=="
+    cf.value = 42
+    cf.save!
+
+    node = NetworkTestHelper.create_node()
+      
+    result = cf.match(node)
+    assert !result
   end
 end

--- a/crowbar_framework/test/unit/role_filter_test.rb
+++ b/crowbar_framework/test/unit/role_filter_test.rb
@@ -1,0 +1,44 @@
+# Copyright 2013, Dell 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+
+require 'test_helper'
+ 
+class RoleFilterTest < ActiveSupport::TestCase
+  test "Test successful match" do
+    cf = RoleFilter.new()
+    cf.pattern = "^dns_.+"
+    cf.save!
+
+    node = Node.create!(:name => "fred.flintstone.org")
+    NetworkTestHelper.add_role(node, "ganglia_client")
+    NetworkTestHelper.add_role(node, "dns_server")
+
+    result = cf.match(node)
+    assert result
+  end
+
+
+  test "Test unsuccessful match" do
+    cf = RoleFilter.new()
+    cf.pattern = "^.*fred.*$"
+    cf.save!
+
+    node = Node.create!(:name => "fred.flintstone.org")
+    NetworkTestHelper.add_role(node, "ganglia_client")
+    NetworkTestHelper.add_role(node, "dns_server")
+      
+    result = cf.match(node)
+    assert !result
+  end
+end


### PR DESCRIPTION
This pull request ports the get_conduits call to CR 2.0.
Part of this pull adds a method to Node to retrieve the roles associate with the node.

 crowbar_framework/app/models/conduit.rb            |   30 +++-
 crowbar_framework/app/models/conduit_filter.rb     |    7 +-
 crowbar_framework/app/models/interface_selector.rb |    2 -
 .../app/models/network_mode_filter.rb              |   20 ++-
 crowbar_framework/app/models/network_service.rb    |   14 +-
 .../app/models/node_attribute_filter.rb            |   10 +-
 crowbar_framework/app/models/role_filter.rb        |   33 +++++
 crowbar_framework/app/models/select_by_index.rb    |    4 -
 crowbar_framework/app/models/select_by_speed.rb    |    4 -
 crowbar_framework/test/network_test_helper.rb      |   23 +++
 crowbar_framework/test/unit/conduit_filter_test.rb |    8 --
 crowbar_framework/test/unit/conduit_test.rb        |  150 ++++++++++++++++++++
 .../test/unit/interface_selector_test.rb           |    8 --
 .../test/unit/network_mode_filter_test.rb          |   42 ++++++
 .../test/unit/node_attribute_filter_test.rb        |   44 ++++++
 crowbar_framework/test/unit/role_filter_test.rb    |   44 ++++++
 16 files changed, 401 insertions(+), 42 deletions(-)

Crowbar-Pull-ID: 05a8fd76682547f32d638919db2c1527298c3f8a

Crowbar-Release: development
