### PR TITLE
Tying together conduit filters and interface selectors [1/1]

### DIFF
--- a/crowbar_framework/app/models/conduit_rule.rb
+++ b/crowbar_framework/app/models/conduit_rule.rb
@@ -21,6 +21,21 @@ class ConduitRule < ActiveRecord::Base
   validates :interface_selectors, :presence => true
 
 
+  def match_filters(node)
+    # Check to see if all of the supplied ConduitFilters match 
+    found_match=true
+    if !self.conduit_filters.nil?
+      self.conduit_filters.each do |conduit_filter|
+        if !conduit_filter.match(node)
+          found_match=false
+          break
+        end
+      end
+    end
+    found_match
+  end
+
+
   def select_interfaces(node)
     # if_remap is a hash that maps "1g1" to "eth0", etc
     if_remap = ConduitRule.build_if_remap(node)


### PR DESCRIPTION
This pull request ties together conduit filters and interface selectors to produce the node map.

 crowbar_framework/app/models/conduit.rb      |   36 ++--
 crowbar_framework/app/models/conduit_rule.rb |   15 ++
 crowbar_framework/test/unit/conduit_test.rb  |  241 +++++++++++++++++++++++---
 3 files changed, 256 insertions(+), 36 deletions(-)

Crowbar-Pull-ID: 0b75b77e0f1d6f64cdc46c11e0778b9cb5f79120

Crowbar-Release: development
