### PR TITLE
Refactor network scaffolding to match what enginization requires with namespacingRefactor network scaffolding to match what enginization requires with namespacing [1/1]

### DIFF
--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/allocated_ip_addresses_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/allocated_ip_addresses_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::AllocatedIpAddressesController < ApplicationController
   active_scaffold :'barclamp_network/allocated_ip_address' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/bmc_interfaces_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/bmc_interfaces_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::BmcInterfacesController < ApplicationController
   active_scaffold :'barclamp_network/bmc_interface' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/bonds_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/bonds_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::BondsController < ApplicationController
   active_scaffold :'barclamp_network/bond' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/bus_maps_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/bus_maps_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::BusMapsController < ApplicationController
   active_scaffold :'barclamp_network/bus_map' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/buses_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/buses_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::BusesController < ApplicationController
   active_scaffold :'barclamp_network/bus' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/conduit_actions_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/conduit_actions_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::ConduitActionsController < ApplicationController
   active_scaffold :'barclamp_network/conduit_action' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/conduit_filters_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/conduit_filters_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::ConduitFiltersController < ApplicationController
   active_scaffold :'barclamp_network/conduit_filter' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/conduit_rules_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/conduit_rules_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::ConduitRulesController < ApplicationController
   active_scaffold :'barclamp_network/conduit_rule' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/conduits_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/conduits_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::ConduitsController < ApplicationController
   active_scaffold :'barclamp_network/conduit' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/create_bonds_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/create_bonds_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::CreateBondsController < ApplicationController
   active_scaffold :'barclamp_network/create_bond' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/create_vlans_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/create_vlans_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::CreateVlansController < ApplicationController
   active_scaffold :'barclamp_network/create_vlan' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/interface_maps_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/interface_maps_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::InterfaceMapsController < ApplicationController
   active_scaffold :'barclamp_network/interface_map' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/interface_selectors_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/interface_selectors_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::InterfaceSelectorsController < ApplicationController
   active_scaffold :'barclamp_network/interface_selector' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/interfaces_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/interfaces_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::InterfacesController < ApplicationController
   active_scaffold :'barclamp_network/interface' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/ip_addresses_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/ip_addresses_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::IpAddressesController < ApplicationController
   active_scaffold :'barclamp_network/ip_address' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/ip_ranges_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/ip_ranges_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::IpRangesController < ApplicationController
   active_scaffold :'barclamp_network/ip_range' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/network_mode_filters_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/network_mode_filters_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::NetworkModeFiltersController < ApplicationController
   active_scaffold :'barclamp_network/network_mode_filter' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/networks_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/networks_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::NetworksController < ApplicationController
   active_scaffold :'barclamp_network/network' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/node_attribute_filters_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/node_attribute_filters_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::NodeAttributeFiltersController < ApplicationController
   active_scaffold :'barclamp_network/node_attribute_filter' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/physical_interfaces_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/physical_interfaces_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::PhysicalInterfacesController < ApplicationController
   active_scaffold :'barclamp_network/physical_interface' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/routers_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/routers_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::RoutersController < ApplicationController
   active_scaffold :'barclamp_network/router' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/select_by_indices_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/select_by_indices_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::SelectByIndicesController < ApplicationController
   active_scaffold :'barclamp_network/select_by_index' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/select_by_speeds_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/select_by_speeds_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::SelectBySpeedsController < ApplicationController
   active_scaffold :'barclamp_network/select_by_speed' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/vlan_interfaces_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/vlan_interfaces_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::VlanInterfacesController < ApplicationController
   active_scaffold :'barclamp_network/vlan_interface' do |conf|
   end

--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/vlans_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/scaffolds/vlans_controller.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+
 class Scaffolds::VlansController < ApplicationController
   active_scaffold :'barclamp_network/vlan' do |conf|
   end


### PR DESCRIPTION
Refactor network scaffolding to match what enginization requires with namespacing

 .../scaffolds/allocated_ip_addresses_controller.rb |    3 ++-
 .../scaffolds/bmc_interfaces_controller.rb         |    3 ++-
 .../barclamp_network/scaffolds/bonds_controller.rb |    3 ++-
 .../scaffolds/bus_maps_controller.rb               |    3 ++-
 .../barclamp_network/scaffolds/buses_controller.rb |    3 ++-
 .../scaffolds/conduit_actions_controller.rb        |    3 ++-
 .../scaffolds/conduit_filters_controller.rb        |    3 ++-
 .../scaffolds/conduit_rules_controller.rb          |    3 ++-
 .../scaffolds/conduits_controller.rb               |    3 ++-
 .../scaffolds/create_bonds_controller.rb           |    3 ++-
 .../scaffolds/create_vlans_controller.rb           |    3 ++-
 .../scaffolds/interface_maps_controller.rb         |    3 ++-
 .../scaffolds/interface_selectors_controller.rb    |    3 ++-
 .../scaffolds/interfaces_controller.rb             |    3 ++-
 .../scaffolds/ip_addresses_controller.rb           |    3 ++-
 .../scaffolds/ip_ranges_controller.rb              |    3 ++-
 .../scaffolds/network_mode_filters_controller.rb   |    3 ++-
 .../scaffolds/networks_controller.rb               |    3 ++-
 .../scaffolds/node_attribute_filters_controller.rb |    3 ++-
 .../scaffolds/physical_interfaces_controller.rb    |    3 ++-
 .../scaffolds/routers_controller.rb                |    3 ++-
 .../scaffolds/select_by_indices_controller.rb      |    3 ++-
 .../scaffolds/select_by_speeds_controller.rb       |    3 ++-
 .../scaffolds/vlan_interfaces_controller.rb        |    3 ++-
 .../barclamp_network/scaffolds/vlans_controller.rb |    3 ++-
 25 files changed, 50 insertions(+), 25 deletions(-)

Crowbar-Pull-ID: 7e33931900fc7862c37e2e3334f4e95119a52f62

Crowbar-Release: development
