### PR TITLE
Reduced specification of table prefix to 1 location [1/1]

### DIFF
--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/attrib_ip_address.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/attrib_ip_address.rb
@@ -44,7 +44,7 @@ class BarclampNetwork::AttribIpAddress < Attrib
 
     network = result
 
-    results = BarclampNetwork::AllocatedIpAddress.joins(:interface).where(:bc_net_interfaces => {:node_id => node.id}).where(:network_id => network.id)
+    results = BarclampNetwork::AllocatedIpAddress.joins(:interface).where("#{BarclampNetwork::TABLE_PREFIX}interfaces" => {:node_id => node.id}).where(:network_id => network.id)
     if results.length == 0
       raise "Node #{BarclampNetwork::NetworkUtils.log_name(node)} does not have an address allocated on Deployment/Snapshot #{BarclampNetwork::NetworkUtils.log_name(network.snapshot.deployment)}/#{BarclampNetwork::NetworkUtils.log_name(network.snapshot)} network #{BarclampNetwork::NetworkUtils.log_name(self)}"
     end

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/interface.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/interface.rb
@@ -18,7 +18,7 @@ class BarclampNetwork::Interface < ActiveRecord::Base
   has_many :allocated_ip_addresses, :inverse_of => :interface, :dependent => :destroy, :class_name => "BarclampNetwork::AllocatedIpAddress"
   belongs_to :vlan_interface, :inverse_of => :interfaces, :class_name => "BarclampNetwork::VlanInterface"
   belongs_to :node
-  has_and_belongs_to_many :networks, :join_table => "bc_net_interfaces_networks", :class_name => "BarclampNetwork::Network"
+  has_and_belongs_to_many :networks, :join_table => "#{BarclampNetwork::TABLE_PREFIX}interfaces_networks", :class_name => "BarclampNetwork::Network"
   
   # attr_accessible :name
 

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/network.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/network.rb
@@ -23,7 +23,7 @@ class BarclampNetwork::Network < ActiveRecord::Base
   has_many :ip_ranges, :dependent => :destroy, :class_name => "BarclampNetwork::IpRange"
   belongs_to :snapshot
   has_one :vlan, :inverse_of => :network, :dependent => :destroy, :class_name => "BarclampNetwork::Vlan"
-  has_and_belongs_to_many :interfaces, :join_table => "bc_net_interfaces_networks", :class_name => "BarclampNetwork::Interface"
+  has_and_belongs_to_many :interfaces, :join_table => "#{BarclampNetwork::TABLE_PREFIX}interfaces_networks", :class_name => "BarclampNetwork::Interface"
 
   # attr_accessible :name, :dhcp_enabled, :use_vlan
 
@@ -43,7 +43,7 @@ class BarclampNetwork::Network < ActiveRecord::Base
     return [400, "No node specified"] if node.nil?
 
     # If the node already has an IP on this network then just return success
-    results = BarclampNetwork::AllocatedIpAddress.joins(:interface).where(:bc_net_interfaces => {:node_id => node.id}).where(:network_id => id)
+    results = BarclampNetwork::AllocatedIpAddress.joins(:interface).where("#{BarclampNetwork::TABLE_PREFIX}interfaces" => {:node_id => node.id}).where(:network_id => id)
     if results.length > 0
       allocated_ip = results.first.ip
       logger.info("Network.allocate_ip: node #{BarclampNetwork::NetworkUtils.log_name(node)} already has address #{allocated_ip} on network #{BarclampNetwork::NetworkUtils.log_name(self)}, range #{range}")
@@ -154,7 +154,7 @@ class BarclampNetwork::Network < ActiveRecord::Base
     return [400, "No node specified"] if node.nil?
 
     # If we don't have one allocated, return success
-    results = BarclampNetwork::AllocatedIpAddress.joins(:interface).where(:bc_net_interfaces => {:node_id => node.id}).where(:network_id => id)
+    results = BarclampNetwork::AllocatedIpAddress.joins(:interface).where("#{BarclampNetwork::TABLE_PREFIX}interfaces" => {:node_id => node.id}).where(:network_id => id)
     if results.length == 0
       logger.warn("Network.deallocate_ip: node #{BarclampNetwork::NetworkUtils.log_name(node)} does not have an address allocated on network #{BarclampNetwork::NetworkUtils.log_name(self)}")
       return [200, nil]

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/network_utils.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/network_utils.rb
@@ -14,8 +14,6 @@
 
 class BarclampNetwork::NetworkUtils
 
-  TABLE_PREFIX = "bc_net_"
-
   ACTIVE_SNAPSHOT = 0
   PROPOSED_SNAPSHOT = 1
 

--- a/crowbar_engine/barclamp_network/db/migrate/20120730175122_create_networks.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120730175122_create_networks.rb
@@ -14,7 +14,7 @@
 
 class CreateNetworks < ActiveRecord::Migration
   def change
-    create_table :bc_net_networks do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}networks" do |t|
       t.string :name
       t.boolean :dhcp_enabled
       t.boolean :use_vlan

--- a/crowbar_engine/barclamp_network/db/migrate/20120730175238_create_interfaces.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120730175238_create_interfaces.rb
@@ -14,7 +14,7 @@
 
 class CreateInterfaces < ActiveRecord::Migration
   def change
-    create_table :bc_net_interfaces do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}interfaces" do |t|
       t.string :type
       t.string :name
       t.integer :team_mode

--- a/crowbar_engine/barclamp_network/db/migrate/20120730175255_create_ip_addresses.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120730175255_create_ip_addresses.rb
@@ -14,7 +14,7 @@
 
 class CreateIpAddresses < ActiveRecord::Migration
   def change
-    create_table :bc_net_ip_addresses do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}ip_addresses" do |t|
       t.string :cidr
       t.integer :subnet_id
       t.integer :router_id

--- a/crowbar_engine/barclamp_network/db/migrate/20120821194639_create_conduits.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120821194639_create_conduits.rb
@@ -14,7 +14,7 @@
 
 class CreateConduits < ActiveRecord::Migration
   def change
-    create_table :bc_net_conduits do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}conduits" do |t|
       t.string :name
       t.references :snapshot
 

--- a/crowbar_engine/barclamp_network/db/migrate/20120822201408_create_routers.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120822201408_create_routers.rb
@@ -14,7 +14,7 @@
 
 class CreateRouters < ActiveRecord::Migration
   def change
-    create_table :bc_net_routers do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}routers" do |t|
       t.integer :pref
       t.references :network
 

--- a/crowbar_engine/barclamp_network/db/migrate/20120827150258_create_ip_ranges.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120827150258_create_ip_ranges.rb
@@ -14,7 +14,7 @@
 
 class CreateIpRanges < ActiveRecord::Migration
   def change
-    create_table :bc_net_ip_ranges do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}ip_ranges" do |t|
       t.string :name
       t.references :network
 

--- a/crowbar_engine/barclamp_network/db/migrate/20120914175602_create_buses.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120914175602_create_buses.rb
@@ -14,7 +14,7 @@
 
 class CreateBuses < ActiveRecord::Migration
   def change
-    create_table :bc_net_buses do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}buses" do |t|
       t.integer :order
       t.string :path
 

--- a/crowbar_engine/barclamp_network/db/migrate/20120914175721_create_bus_maps.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120914175721_create_bus_maps.rb
@@ -14,7 +14,7 @@
 
 class CreateBusMaps < ActiveRecord::Migration
   def change
-    create_table :bc_net_bus_maps do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}bus_maps" do |t|
       t.string :pattern
 
       t.references :interface_map

--- a/crowbar_engine/barclamp_network/db/migrate/20120914175733_create_interface_maps.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120914175733_create_interface_maps.rb
@@ -14,7 +14,7 @@
 
 class CreateInterfaceMaps < ActiveRecord::Migration
   def change
-    create_table :bc_net_interface_maps do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}interface_maps" do |t|
       t.references :snapshot
 
       t.timestamps

--- a/crowbar_engine/barclamp_network/db/migrate/20120918205152_create_interface_selectors.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120918205152_create_interface_selectors.rb
@@ -14,7 +14,7 @@
 
 class CreateInterfaceSelectors < ActiveRecord::Migration
   def change
-    create_table :bc_net_interface_selectors do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}interface_selectors" do |t|
       t.references :conduit_rule
 
       t.timestamps

--- a/crowbar_engine/barclamp_network/db/migrate/20120918205303_create_conduit_filters.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120918205303_create_conduit_filters.rb
@@ -14,7 +14,7 @@
 
 class CreateConduitFilters < ActiveRecord::Migration
   def change
-    create_table :bc_net_conduit_filters do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}conduit_filters" do |t|
       t.references :conduit_rule
       t.string :type
       t.string :attr

--- a/crowbar_engine/barclamp_network/db/migrate/20120919110841_create_conduit_actions.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120919110841_create_conduit_actions.rb
@@ -14,7 +14,7 @@
 
 class CreateConduitActions < ActiveRecord::Migration
   def change
-    create_table :bc_net_conduit_actions do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}conduit_actions" do |t|
       t.references :conduit_rule
       t.string :type
       t.string :name

--- a/crowbar_engine/barclamp_network/db/migrate/20120919190544_create_conduit_rules.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20120919190544_create_conduit_rules.rb
@@ -14,7 +14,7 @@
 
 class CreateConduitRules < ActiveRecord::Migration
   def change
-    create_table :bc_net_conduit_rules do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}conduit_rules" do |t|
 
       t.references :conduit
       t.timestamps

--- a/crowbar_engine/barclamp_network/db/migrate/20121214183538_create_vlans.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20121214183538_create_vlans.rb
@@ -14,7 +14,7 @@
 
 class CreateVlans < ActiveRecord::Migration
   def change
-    create_table :bc_net_vlans do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}vlans" do |t|
       t.integer :tag
       t.references :network
 

--- a/crowbar_engine/barclamp_network/db/migrate/20130112145100_create_selectors.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20130112145100_create_selectors.rb
@@ -14,7 +14,7 @@
 
 class CreateSelectors < ActiveRecord::Migration
   def change
-    create_table :bc_net_selectors do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}selectors" do |t|
       t.references :interface_selector
       t.string :type
       t.string :value

--- a/crowbar_engine/barclamp_network/db/migrate/20130115220245_create_allocated_ip_addresses.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20130115220245_create_allocated_ip_addresses.rb
@@ -14,7 +14,7 @@
 
 class CreateAllocatedIpAddresses < ActiveRecord::Migration
   def change
-    create_table :bc_net_allocated_ip_addresses do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}allocated_ip_addresses" do |t|
       t.string :ip
       t.references :interface
       t.references :network
@@ -22,6 +22,6 @@ class CreateAllocatedIpAddresses < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index(:bc_net_allocated_ip_addresses, [:ip, :network_id], :unique => true, :name => "by_ip_network")
+    add_index("#{BarclampNetwork::TABLE_PREFIX}allocated_ip_addresses", [:ip, :network_id], :unique => true, :name => "by_ip_network")
   end
 end

--- a/crowbar_engine/barclamp_network/db/migrate/20130123083500_create_interfaces_networks.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20130123083500_create_interfaces_networks.rb
@@ -14,10 +14,10 @@
 #
 class CreateInterfacesNetworks < ActiveRecord::Migration
   def change
-    create_table :bc_net_interfaces_networks, :id=>false do |t|
+    create_table "#{BarclampNetwork::TABLE_PREFIX}interfaces_networks", :id=>false do |t|
       t.references  :interface
       t.references  :network
     end
-    add_index(:bc_net_interfaces_networks, [:interface_id, :network_id], :unique => true)
+    add_index("#{BarclampNetwork::TABLE_PREFIX}interfaces_networks", [:interface_id, :network_id], :unique => true)
   end
 end

--- a/crowbar_engine/barclamp_network/lib/barclamp_network.rb
+++ b/crowbar_engine/barclamp_network/lib/barclamp_network.rb
@@ -1,7 +1,11 @@
 require "barclamp_network/engine"
 
 module BarclampNetwork
+
+  TABLE_PREFIX = "bc_net_"
+
+  
   def self.table_name_prefix
-    "bc_net_"
+    TABLE_PREFIX
   end
 end


### PR DESCRIPTION
Reduced the specification of the table name prefix to 1 location.

 .../models/barclamp_network/attrib_ip_address.rb   |    2 +-
 .../app/models/barclamp_network/interface.rb       |    2 +-
 .../app/models/barclamp_network/network.rb         |    6 +++---
 .../app/models/barclamp_network/network_utils.rb   |    2 --
 .../db/migrate/20120730175122_create_networks.rb   |    2 +-
 .../db/migrate/20120730175238_create_interfaces.rb |    2 +-
 .../migrate/20120730175255_create_ip_addresses.rb  |    2 +-
 .../db/migrate/20120821194639_create_conduits.rb   |    2 +-
 .../db/migrate/20120822201408_create_routers.rb    |    2 +-
 .../db/migrate/20120827150258_create_ip_ranges.rb  |    2 +-
 .../db/migrate/20120914175602_create_buses.rb      |    2 +-
 .../db/migrate/20120914175721_create_bus_maps.rb   |    2 +-
 .../20120914175733_create_interface_maps.rb        |    2 +-
 .../20120918205152_create_interface_selectors.rb   |    2 +-
 .../20120918205303_create_conduit_filters.rb       |    2 +-
 .../20120919110841_create_conduit_actions.rb       |    2 +-
 .../migrate/20120919190544_create_conduit_rules.rb |    2 +-
 .../db/migrate/20121214183538_create_vlans.rb      |    2 +-
 .../db/migrate/20130112145100_create_selectors.rb  |    2 +-
 ...20130115220245_create_allocated_ip_addresses.rb |    4 ++--
 .../20130123083500_create_interfaces_networks.rb   |    4 ++--
 .../barclamp_network/lib/barclamp_network.rb       |    6 +++++-
 22 files changed, 29 insertions(+), 27 deletions(-)

Crowbar-Pull-ID: c5c567a3f927d8fc8627a3a65daee3166fb86856

Crowbar-Release: development
