### PR TITLE
Fix issues in network barclamp exposed by Travis [1/1]

### DIFF
--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/node_attribute_filter.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/node_attribute_filter.rb
@@ -14,11 +14,21 @@
 
 class BarclampNetwork::NodeAttributeFilter < BarclampNetwork::ConduitFilter
   def match(node)
-    attr_name = self.attr.split(".")
-    attrib = node.get_attrib(attr_name[0])
+    self.attr =~ /([^.]+)(\..+)?/
+    match = Regexp.last_match
+    attr_name = match[1]
+    attrib = node.get_attrib(attr_name)
 
-    op_str = ".#{attr_name[1]}" if attr_name.length > 1
+    eval_str = "self.value #{self.comparitor} attrib.value()#{match[2]}"
 
-    eval "self.value #{self.comparitor} attrib.value()#{op_str}"
+    begin
+      result = eval eval_str
+    rescue => ex
+      Rails.logger.error("Caught an exception while evaluating \"#{eval_str}\"")
+      Rails.logger.error("#{ex.message}")
+      Rails.logger.error("#{ex.backtrack.join('\n')}")
+    end
+
+    result
   end
 end

--- a/crowbar_engine/barclamp_network/test/unit/conduit_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/conduit_test.rb
@@ -64,7 +64,7 @@ class ConduitTest < ActiveSupport::TestCase
     destroy_preloaded_conduits()
 
     # Create a node with a couple of Roles
-    node = Node.new(:name => "fred.flintstone.org")
+    node = NetworkTestHelper.create_node()
 
     NetworkTestHelper.add_role(snapshot, node, "ganglia_client")
     NetworkTestHelper.add_role(snapshot, node, "dns_server")
@@ -94,7 +94,7 @@ class ConduitTest < ActiveSupport::TestCase
     rule1.conduit_filters << BarclampNetwork::RoleFilter.create!(:value => "^ganglia_.+")
 
     naf1 = BarclampNetwork::NodeAttributeFilter.new()
-    naf1.attr = "nics.size"
+    naf1.attr = "nics.size.to_s"
     naf1.comparitor = "=="
     naf1.value = "2"
     rule1.conduit_filters << naf1
@@ -120,7 +120,7 @@ class ConduitTest < ActiveSupport::TestCase
     rule2.conduit_filters << BarclampNetwork::RoleFilter.create!(:value => "^dns_.+")
 
     naf2 = BarclampNetwork::NodeAttributeFilter.new()
-    naf2.attr = "nics.size"
+    naf2.attr = "nics.size.to_s"
     naf2.comparitor = "=="
     naf2.value = "2"
     rule2.conduit_filters << naf2
@@ -153,7 +153,7 @@ class ConduitTest < ActiveSupport::TestCase
     rule3.conduit_filters << BarclampNetwork::RoleFilter.create!(:value => "^dns_.+")
 
     naf3 = BarclampNetwork::NodeAttributeFilter.new()
-    naf3.attr = "nics.size"
+    naf3.attr = "nics.size.to_s"
     naf3.comparitor = "=="
     naf3.value = "42"
     rule3.conduit_filters << naf3
@@ -179,7 +179,7 @@ class ConduitTest < ActiveSupport::TestCase
     rule4.conduit_filters << BarclampNetwork::RoleFilter.create!(:value => "^ganglia_.+")
 
     naf4 = BarclampNetwork::NodeAttributeFilter.new()
-    naf4.attr = "nics.size"
+    naf4.attr = "nics.size.to_s"
     naf4.comparitor = "=="
     naf4.value = "2"
     rule4.conduit_filters << naf4
@@ -213,10 +213,12 @@ class ConduitTest < ActiveSupport::TestCase
     result = BarclampNetwork::Conduit.get_conduit_rules(node)
 
     result_conduit_rule1 = result["intf0"]
-    assert rule1, result_conduit_rule1
+    assert_not_nil result_conduit_rule1
+    assert_equal rule1.id, result_conduit_rule1.id
 
     result_conduit_rule2 = result["intf1"]
-    assert rule4, result_conduit_rule2
+    assert_not_nil result_conduit_rule2
+    assert_equal rule4.id, result_conduit_rule2.id
 
     result_conduit_rule3 = result["intf2"]
     assert result_conduit_rule3.nil?

--- a/crowbar_engine/barclamp_network/test/unit/config_action_model_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/config_action_model_test.rb
@@ -35,10 +35,10 @@ class ConfigActionModelTest < ActiveSupport::TestCase
 
     actions = BarclampNetwork::ConfigAction.create_actions(actions_config)
 
-    assert 3, actions.size
-    assert 1, actions[0].order
-    assert 2, actions[1].order
-    assert 3, actions[2].order
+    assert_equal 3, actions.size
+    assert_equal 1, actions[0].order
+    assert_equal 2, actions[1].order
+    assert_equal 3, actions[2].order
     assert actions[0].instance_of? BarclampNetwork::ConfigAction
     assert actions[1].instance_of? BarclampNetwork::CreateBond
     assert actions[2].instance_of? BarclampNetwork::CreateVlan

--- a/crowbar_engine/barclamp_network/test/unit/create_bridge_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/create_bridge_test.rb
@@ -26,8 +26,8 @@ class CreateBridgeTest < ActiveSupport::TestCase
   test "CreateBridge creation: success with ip" do
     actions = create_bridge_with_ip()
     
-    assert 1, actions.size
-    assert 1, actions[0].order
+    assert_equal 1, actions.size
+    assert_equal 1, actions[0].order
     assert actions[0].instance_of? BarclampNetwork::CreateBridge
     assert_equal "192.168.123.1", actions[0].ip.cidr
   end

--- a/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
@@ -72,7 +72,7 @@ class NetworkUtilsTest < ActiveSupport::TestCase
     network.save!
 
     http_error, network = BarclampNetwork::NetworkUtils.find_network("public")
-    assert_equal 200, http_error
+    assert_equal 200, http_error, "Return code of 200 expected, got #{http_error}: #{network}"
     assert_not_nil network
     assert_equal network.snapshot.id, deployment.proposed_snapshot.id
   end


### PR DESCRIPTION
This pull fixes several issues identified by Travis in the network barclamp.

One issue may remain, but additional logging was added to help identify the issue if so.

 .../barclamp_network/node_attribute_filter.rb      |   18 ++++++++++++++----
 .../barclamp_network/test/unit/conduit_test.rb     |   16 +++++++++-------
 .../test/unit/config_action_model_test.rb          |    8 ++++----
 .../test/unit/create_bridge_test.rb                |    4 ++--
 .../test/unit/network_utils_test.rb                |    2 +-
 5 files changed, 30 insertions(+), 18 deletions(-)

Crowbar-Pull-ID: 1d7a19a472721e56526bfa59955ce4a3891c3e6a

Crowbar-Release: development
