### PR TITLE
Debugging for network barclamp travis issue [1/1]

### DIFF
--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/network_utils.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/network_utils.rb
@@ -28,8 +28,30 @@ class BarclampNetwork::NetworkUtils
     return [404, "There is no Deployment with id #{deployment_id}"] if deployment.nil?
 
     # If there is no proposed, then return the active one instead
+    puts("Requested snapshot_type=#{snapshot_type}")
     snapshot_type = ACTIVE_SNAPSHOT if snapshot_type == PROPOSED_SNAPSHOT && deployment.proposed_snapshot.nil?
+    puts("Using snapshot_type=#{snapshot_type}")
     snapshot = (snapshot_type == ACTIVE_SNAPSHOT ? deployment.active :  deployment.proposed)
+
+    if deployment.active.nil?
+      puts("fn: deployment.active=nil")
+    else
+      puts("fn: deployment.active.id=#{deployment.active.id}")
+    end
+
+    if deployment.proposed.nil?
+      puts("deployment.proposed=nil")
+    else
+      puts("deployment.proposed.id=#{deployment.proposed.id}")
+    end
+
+    if snapshot.nil?
+      puts("snapshot=nil")
+    else
+      puts("snapshot.id=#{snapshot.id}")
+      puts("snapshot is the active one") if !deployment.active.nil? and snapshot.id == deployment.active.id
+      puts("snapshot is the proposed one") if !deployment.proposed.nil? and snapshot.id == deployment.proposed.id
+    end
 
     return [404, "There is no active snapshot"] if snapshot.nil?
 
@@ -48,6 +70,7 @@ class BarclampNetwork::NetworkUtils
       end
     else
       # network_id is a name, so look up the network by Snapshot ID and network name
+      puts("Looking up Networks by snapshot_id=#{snapshot.id}, and network_id=#{network_id}")
       network = BarclampNetwork::Network.where("snapshot_id = ? AND name = ?", snapshot.id, network_id).first
       return [404, "There is no network #{network_id} with Deployment/Instance #{log_name(deployment)}/#{log_name(snapshot)}"] if network.nil?
     end

--- a/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
@@ -66,12 +66,36 @@ class NetworkUtilsTest < ActiveSupport::TestCase
   # Successfully find network when only network name supplied
   test "find_network: success when only network name supplied" do
     barclamp = NetworkTestHelper.create_a_barclamp()
+    puts("Starting test")
     deployment = barclamp.create_proposal()
 
     network = NetworkTestHelper.create_a_network(deployment, "public")
     network.save!
+    puts("network.id=#{network.id}, network.name=#{network.name}, network.snapshot.id=#{network.snapshot.id}")
+
+    if deployment.proposed.nil?
+      puts("deployment.proposed=nil")
+    else
+      puts("deployment.proposed.id=#{deployment.proposed.id}")
+    end
+
+    if deployment.active.nil?
+      puts("deployment.active=nil")
+    else
+      puts("deployment.active.id=#{deployment.active.id}")
+    end
 
     http_error, network = BarclampNetwork::NetworkUtils.find_network("public")
+
+    puts("Listing all networks")
+    BarclampNetwork::Network.all.each { |network|
+      puts("l network.id=#{network.id}, network.name=#{network.name}")
+      puts("l network.snapshot=nil") if network.snapshot.nil?
+      puts("l network.snapshot.id=#{network.snapshot.id}") if !network.snapshot.nil?
+    }
+    puts("Done listing all networks")
+
+    puts("Examining test results")
     assert_equal 200, http_error, "Return code of 200 expected, got #{http_error}: #{network}"
     assert_not_nil network
     assert_equal network.snapshot.id, deployment.proposed_snapshot.id


### PR DESCRIPTION
Temporarily adding puts logging into part of the network barclamp to enable debugging of an issue that only occurs on the Travis CI system.

 .../app/models/barclamp_network/network_utils.rb   |   23 +++++++++++++++++++
 .../test/unit/network_utils_test.rb                |   24 ++++++++++++++++++++
 2 files changed, 47 insertions(+)

Crowbar-Pull-ID: 1873fb1eea0ac69cf47e11f6f135e05ba18786ff

Crowbar-Release: development
