### PR TITLE
Final Travis fix in network barclamp [2/2]

### DIFF
--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/barclamp.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/barclamp.rb
@@ -19,6 +19,9 @@ class BarclampNetwork::Barclamp < Barclamp
   end
 
 
+  BARCLAMP_NAME = "network"
+
+
   def create_deployment(deployment_name=nil)
     deployment = super
 

--- a/crowbar_engine/barclamp_network/test/network_test_helper.rb
+++ b/crowbar_engine/barclamp_network/test/network_test_helper.rb
@@ -165,15 +165,18 @@ class NetworkTestHelper
 
 
   def self.create_a_barclamp()
-    barclamp = BarclampNetwork::Barclamp.new(:name => "default")
-    barclamp.save!
+    barclamp = BarclampNetwork::Barclamp.find_key(BarclampNetwork::Barclamp::BARCLAMP_NAME)
+    if barclamp.nil?
+      barclamp = BarclampNetwork::Barclamp.new(:name => BarclampNetwork::Barclamp::BARCLAMP_NAME)
+      barclamp.save!
 
-    snapshot = Snapshot.new()
-    snapshot.barclamp = barclamp
-    snapshot.save!
+      snapshot = Snapshot.new()
+      snapshot.barclamp = barclamp
+      snapshot.save!
 
-    barclamp.template = snapshot
-    barclamp.save!
+      barclamp.template = snapshot
+      barclamp.save!
+    end
     barclamp
   end
 end

--- a/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
@@ -19,7 +19,7 @@ class NetworkUtilsTest < ActiveSupport::TestCase
   # Failure to find Deployment due to bad id
   test "find_network: failure to find Deployment due to bad id" do
     http_error, result = BarclampNetwork::NetworkUtils.find_network("fred", "badbcc")
-    assert_equal 404, http_error
+    assert_equal 404, http_error, result
   end
 
 
@@ -29,7 +29,7 @@ class NetworkUtilsTest < ActiveSupport::TestCase
     deployment = barclamp.create_proposal()
 
     http_error, result = BarclampNetwork::NetworkUtils.find_network("fred", deployment.id, BarclampNetwork::NetworkUtils::ACTIVE_SNAPSHOT)
-    assert_equal 404, http_error
+    assert_equal 404, http_error, result
   end
 
 
@@ -39,7 +39,7 @@ class NetworkUtilsTest < ActiveSupport::TestCase
     deployment = barclamp.create_proposal()
 
     http_error, result = BarclampNetwork::NetworkUtils.find_network("fred", deployment.id)
-    assert_equal 404, http_error
+    assert_equal 404, http_error, result
   end
 
 
@@ -59,43 +59,20 @@ class NetworkUtilsTest < ActiveSupport::TestCase
     network.save!
 
     http_error, network = BarclampNetwork::NetworkUtils.find_network(network.id)
-    assert_equal 400, http_error
+    assert_equal 400, http_error, network
   end
 
 
   # Successfully find network when only network name supplied
   test "find_network: success when only network name supplied" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    puts("Starting test")
     deployment = barclamp.create_proposal()
 
     network = NetworkTestHelper.create_a_network(deployment, "public")
     network.save!
-    puts("network.id=#{network.id}, network.name=#{network.name}, network.snapshot.id=#{network.snapshot.id}")
-
-    if deployment.proposed.nil?
-      puts("deployment.proposed=nil")
-    else
-      puts("deployment.proposed.id=#{deployment.proposed.id}")
-    end
-
-    if deployment.active.nil?
-      puts("deployment.active=nil")
-    else
-      puts("deployment.active.id=#{deployment.active.id}")
-    end
 
     http_error, network = BarclampNetwork::NetworkUtils.find_network("public")
 
-    puts("Listing all networks")
-    BarclampNetwork::Network.all.each { |network|
-      puts("l network.id=#{network.id}, network.name=#{network.name}")
-      puts("l network.snapshot=nil") if network.snapshot.nil?
-      puts("l network.snapshot.id=#{network.snapshot.id}") if !network.snapshot.nil?
-    }
-    puts("Done listing all networks")
-
-    puts("Examining test results")
     assert_equal 200, http_error, "Return code of 200 expected, got #{http_error}: #{network}"
     assert_not_nil network
     assert_equal network.snapshot.id, deployment.proposed_snapshot.id
@@ -110,23 +87,23 @@ class NetworkUtilsTest < ActiveSupport::TestCase
     network = NetworkTestHelper.create_a_network(deployment, "public")
     network.save!
 
-    http_error, network = BarclampNetwork::NetworkUtils.find_network("public", deployment)
-    assert_equal 200, http_error
+    http_error, network = BarclampNetwork::NetworkUtils.find_network("public", deployment.id)
+    assert_equal 200, http_error, network
     assert_not_nil network
     assert_equal network.snapshot.id, deployment.proposed_snapshot.id
   end
 
 
   # Successfully find network when network name, Deployment, and proposed type supplied
-  test "find_network: success when network name, Deployment, and active supplied" do
+  test "find_network: success when network name, Deployment, and proposed supplied" do
     barclamp = NetworkTestHelper.create_a_barclamp()
     deployment = barclamp.create_proposal()
 
     network = NetworkTestHelper.create_a_network(deployment, "public")
     network.save!
 
-    http_error, network = BarclampNetwork::NetworkUtils.find_network("public", deployment, BarclampNetwork::NetworkUtils::PROPOSED_SNAPSHOT)
-    assert_equal 200, http_error
+    http_error, network = BarclampNetwork::NetworkUtils.find_network("public", deployment.id, BarclampNetwork::NetworkUtils::PROPOSED_SNAPSHOT)
+    assert_equal 200, http_error, network
     assert_not_nil network
     assert_equal network.snapshot.id, deployment.proposed_snapshot.id
   end


### PR DESCRIPTION
This pull contains a fix for the final nagging Travis issue in the network barclamp.
The creation of the network barclamp is now conditional in the unit tests.
The name of the network barclamp is changed from "default" to "network" as it should be.

 .../app/models/barclamp_network/barclamp.rb        |    3 ++
 .../app/models/barclamp_network/network_utils.rb   |   36 ++++++-----------
 .../barclamp_network/test/network_test_helper.rb   |   17 ++++----
 .../test/unit/network_utils_test.rb                |   41 +++++---------------
 4 files changed, 33 insertions(+), 64 deletions(-)

Crowbar-Pull-ID: b9a7a2c1b452c95169ed23db7d379806d41d7c8c

Crowbar-Release: development
