### PR TITLE
Create default network barclamp deployment in DB migration [1/1]

### DIFF
--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/barclamp.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/barclamp.rb
@@ -22,13 +22,24 @@ class BarclampNetwork::Barclamp < Barclamp
   BARCLAMP_NAME = "network"
 
 
+  def create_or_get_deployment(deployment_name=nil)
+    deployment = create_deployment(deployment_name)
+    deployment = deployments[0] if deployment.nil?
+    deployment
+  end
+
+
   def create_deployment(deployment_name=nil)
     deployment = super
 
-    json = BarclampNetwork::Barclamp.read_network_json()
-    attrs_config = json["attributes"]
+    # super will only return a deployment if it creates a new one
+    if !deployment.nil?
+      json = BarclampNetwork::Barclamp.read_network_json()
+      attrs_config = json["attributes"]
 
-    populate_network_defaults( attrs_config["network"], deployment.proposed_snapshot )
+      populate_network_defaults( attrs_config["network"], deployment.proposed_snapshot )
+    end
+
     deployment
   end
 

--- a/crowbar_engine/barclamp_network/db/migrate/20130312110000_create_deployment.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20130312110000_create_deployment.rb
@@ -1,0 +1,32 @@
+# Copyright 2013, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a pretty nasty hack to create the default network barclamp deployment
+#
+# This is being done this way for now so that the default deployment will be
+# created in both the dev test environment and in production mode
+#
+# TODO: Remove this
+
+class CreateDeployment < ActiveRecord::Migration
+  def self.up
+    barclamp = BarclampNetwork::Barclamp.find_key(BarclampNetwork::Barclamp::BARCLAMP_NAME)
+    barclamp.create_deployment("Default")
+  end
+
+  def self.down
+    # TODO
+  end
+end
+

--- a/crowbar_engine/barclamp_network/test/unit/allocated_ip_address_model.rb
+++ b/crowbar_engine/barclamp_network/test/unit/allocated_ip_address_model.rb
@@ -18,7 +18,7 @@ class AllocatedIpAddressModelTest < ActiveSupport::TestCase
   # Test creation failure, no ip
   test "AllocatedIpAddress creation: failure no ip" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -45,7 +45,7 @@ class AllocatedIpAddressModelTest < ActiveSupport::TestCase
   # Test successful creation, min
   test "AllocatedIpAddress creation: min success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -59,7 +59,7 @@ class AllocatedIpAddressModelTest < ActiveSupport::TestCase
   # Test successful creation, max
   test "AllocatedIpAddress creation: max success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -73,7 +73,7 @@ class AllocatedIpAddressModelTest < ActiveSupport::TestCase
   # Test successful creation, normal
   test "AllocatedIpAddress creation: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -87,7 +87,7 @@ class AllocatedIpAddressModelTest < ActiveSupport::TestCase
   # Test validation: alpha
   test "AllocatedIpAddress creation: alpha failure" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -103,7 +103,7 @@ class AllocatedIpAddressModelTest < ActiveSupport::TestCase
   # Test validation: overflow 1st octet
   test "AllocatedIpAddress creation: 1st octet overflow failure" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -120,7 +120,7 @@ class AllocatedIpAddressModelTest < ActiveSupport::TestCase
   # Test validation: overflow 2nd octet
   test "AllocatedIpAddress creation: 2nd octet overflow failure" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -137,7 +137,7 @@ class AllocatedIpAddressModelTest < ActiveSupport::TestCase
   # Test validation: overflow 3rd octet
   test "AllocatedIpAddress creation: 3rd octet overflow failure" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -154,7 +154,7 @@ class AllocatedIpAddressModelTest < ActiveSupport::TestCase
   # Test validation: overflow 4th octet
   test "AllocatedIpAddress creation: 4th octet overflow failure" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!

--- a/crowbar_engine/barclamp_network/test/unit/attrib_bus_order_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/attrib_bus_order_test.rb
@@ -19,7 +19,7 @@ class AttribBusOrderTest < ActiveSupport::TestCase
   # Test retrieval of bus order
   test "BusOrder retrieval: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     interface_map = NetworkTestHelper.create_an_interface_map(deployment)
     interface_map.save!

--- a/crowbar_engine/barclamp_network/test/unit/attrib_ip_address_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/attrib_ip_address_test.rb
@@ -19,7 +19,7 @@ class AttribIpAddressTest < ActiveSupport::TestCase
   # Test retrieval of ip address for default network
   test "Ip address retrieval: default network success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = Node.new(:name => "fred.flintstone.org")
     node.save!
@@ -34,7 +34,7 @@ class AttribIpAddressTest < ActiveSupport::TestCase
   # Test retrieval of ip address for specified network
   test "Ip address retrieval: specified network success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = Node.new(:name => "fred7.flintstone.org")
     node.save!

--- a/crowbar_engine/barclamp_network/test/unit/conduit_rule_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/conduit_rule_test.rb
@@ -92,7 +92,7 @@ class ConduitRuleTest < ActiveSupport::TestCase
 
   test "ConduitRule.sort_ifs: Test proper interface sorting when product_name in interface map" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = NetworkTestHelper.create_node()
     node.set_attrib("product_name", "PowerEdge C6145")
@@ -110,7 +110,7 @@ class ConduitRuleTest < ActiveSupport::TestCase
 
   test "ConduitRule.sort_ifs: Test proper interface sorting when product_name not in interface map" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = NetworkTestHelper.create_node()
     node.set_attrib("product_name", "Magical Mystery Box")
@@ -128,7 +128,7 @@ class ConduitRuleTest < ActiveSupport::TestCase
 
   test "ConduitRule.build_if_remap: Remap with known product name" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = NetworkTestHelper.create_node()
     node.set_attrib("product_name", "PowerEdge C6145")
@@ -155,7 +155,7 @@ class ConduitRuleTest < ActiveSupport::TestCase
 
   test "ConduitRule.build_if_remap: Remap with unknown product name" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = NetworkTestHelper.create_node()
     node.set_attrib("product_name", "Magical Mystery Box")
@@ -287,7 +287,7 @@ class ConduitRuleTest < ActiveSupport::TestCase
 
   def test_select_interfaces(ifs_selector)
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = NetworkTestHelper.create_node()
     node.set_attrib("product_name", "PowerEdge C6145")

--- a/crowbar_engine/barclamp_network/test/unit/conduit_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/conduit_test.rb
@@ -20,7 +20,7 @@ class ConduitTest < ActiveSupport::TestCase
   # Test successful creation
   test "Conduit creation: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
     destroy_preloaded_conduits()
 
     conduit = NetworkTestHelper.create_or_get_conduit(deployment, "intf0")
@@ -41,7 +41,7 @@ class ConduitTest < ActiveSupport::TestCase
   # Test delete cascade
   test "Conduit deletion: cascade to conduit rules" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
     destroy_preloaded_conduits()
 
     conduit = NetworkTestHelper.create_or_get_conduit(deployment, "intf0")
@@ -59,7 +59,7 @@ class ConduitTest < ActiveSupport::TestCase
   # Test successful retrieval of conduit rules
   test "Successful retrieval of conduit rules" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
     snapshot = deployment.proposed_snapshot
     destroy_preloaded_conduits()
 
@@ -363,7 +363,7 @@ class ConduitTest < ActiveSupport::TestCase
 
   def test_build_node_map(role_pattern, c1_intf_selectors, c2_intf_selectors)
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
     snapshot = deployment.proposed_snapshot
     destroy_preloaded_conduits()
 

--- a/crowbar_engine/barclamp_network/test/unit/interface_map_model_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/interface_map_model_test.rb
@@ -19,7 +19,7 @@ class InterfaceMapModelTest < ActiveSupport::TestCase
   # Test successful creation
   test "InterfaceMap creation: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     interface_map = NetworkTestHelper.create_an_interface_map(deployment)
     interface_map.save!
@@ -37,7 +37,7 @@ class InterfaceMapModelTest < ActiveSupport::TestCase
   # Test deletion cascade to BusMaps
   test "IntefaceMap deletion: cascade" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     interface_map = NetworkTestHelper.create_an_interface_map(deployment)
     interface_map.save!
@@ -53,7 +53,7 @@ class InterfaceMapModelTest < ActiveSupport::TestCase
   # Test retrieval of a bus order
   test "InterfaceMap: retrieval of bus order success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     interface_map = NetworkTestHelper.create_an_interface_map(deployment)
     interface_map.save!
@@ -74,7 +74,7 @@ class InterfaceMapModelTest < ActiveSupport::TestCase
   # Test failure to retrieve bus order
   test "InterfaceMap: retrieval of bus order failure" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     interface_map = NetworkTestHelper.create_an_interface_map(deployment)
     interface_map.save!

--- a/crowbar_engine/barclamp_network/test/unit/interface_model_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/interface_model_test.rb
@@ -35,7 +35,7 @@ class InterfaceModelTest < ActiveSupport::TestCase
   # Test cascade allocated ip deletion on interface deletion
   test "Interface deletion: cascade delete to allocated ips" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!

--- a/crowbar_engine/barclamp_network/test/unit/network_barclamp_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/network_barclamp_test.rb
@@ -20,7 +20,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test creation
   test "network_create: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     create_a_network(barclamp, deployment, "public")
   end
@@ -29,7 +29,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test failed network creation due to missing router_pref
   test "network_create: missing router_pref" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     http_error, network = barclamp.network_create(
         deployment.id,
@@ -48,7 +48,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test failed network creation due to missing router_ip
   test "network_create: missing router_ip" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     http_error, network = barclamp.network_create(
         deployment.id,
@@ -67,7 +67,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test failed network creation due to missing ip range
   test "network_create: missing no ip range" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     http_error, network = barclamp.network_create(
         deployment.id,
@@ -86,7 +86,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test retrieval by name
   test "network_get: by name success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     net_name="public"
     create_a_network(barclamp, deployment, net_name)
@@ -100,7 +100,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test retrieval by id
   test "network_get: by id success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     net_name="public"
     network = create_a_network(barclamp, deployment, net_name)
@@ -115,7 +115,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test retrieval of non-existant object
   test "network_get: non-existant network" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     # Get by name
     http_error, network = barclamp.network_get(deployment.id, "zippityDoDa")
@@ -127,7 +127,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test adding an ip range
   test "network_update: add ip range" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     net_name="public"
     create_a_network(barclamp, deployment, net_name)
@@ -151,7 +151,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test removing an ip range
   test "network_update: remove ip range" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     net_name = "public"
     create_a_network(barclamp, deployment, net_name)
@@ -175,7 +175,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test removing all IP ranges from a network
   test "network_update: remove all ip ranges" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     net_name = "public"
     create_a_network(barclamp, deployment, net_name)
@@ -197,7 +197,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test updating to an IP range that has no start
   test "network_update: ip range with no start" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     net_name = "public"
     create_a_network(barclamp, deployment, net_name)
@@ -219,7 +219,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test updating to an IP range that has no end
   test "network_update: ip range with no end" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     net_name = "public"
     create_a_network(barclamp, deployment, net_name)
@@ -241,7 +241,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test failed network update due to missing router_pref
   test "network_update: missing router_pref" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     net_name = "public"
     create_a_network(barclamp, deployment, net_name)
@@ -263,7 +263,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test failed network update due to missing router_ip
   test "network_update: missing router_ip" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     net_name = "public"
     create_a_network(barclamp, deployment, net_name)
@@ -285,7 +285,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test deletion of non-existant network
   test "network_delete: non-existant network" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     delete_nonexistant_network( barclamp, deployment.id, "zippityDoDa")
   end
@@ -294,7 +294,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test deletion
   test "network_delete: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     net_name = "public"
     create_a_network(barclamp, deployment, net_name)
@@ -311,11 +311,11 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Test population of network defaults
   test "network_defaults_populate" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
-    assert BarclampNetwork::Conduit.count > 0, "There are no Conduits"
-    assert BarclampNetwork::InterfaceMap.count == 1, "There is no InterfaceMap"
-    assert BarclampNetwork::Network.count > 0, "There are no Networks"
+    assert BarclampNetwork::Conduit.all.count > 0, "There are no Conduits"
+    assert BarclampNetwork::InterfaceMap.all.count == 1, "There are #{BarclampNetwork::InterfaceMap.all.count} InterfaceMaps"
+    assert BarclampNetwork::Network.all.count > 0, "There are no Networks"
   end
 
 
@@ -356,7 +356,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Allocate IP success - perfect path
   test "network_allocate_ip: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = Node.new(:name => "fred.flintstone.org")
     node.save!
@@ -406,7 +406,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Deallocate IP success - perfect path
   test "network_deallocate_ip: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = Node.new(:name => "fred.flintstone.org")
     node.save!
@@ -429,7 +429,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Enable interface failure due to missing network_id
   test "network_enable_interface: failure due to missing network_id" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     http_error, message = barclamp.network_enable_interface(deployment.id,nil,"fred")
     assert_equal 400, http_error
@@ -439,7 +439,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Enable interface failure due to missing node_id
   test "network_enable_interface: failure due to missing node_id" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     http_error, message = barclamp.network_enable_interface(deployment.id,"network1",nil)
     assert_equal 400, http_error
@@ -449,7 +449,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Enable interface failure due to bad node_id
   test "network_enable_interface: failure due to bad node_id" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     http_error, message = barclamp.network_enable_interface(deployment.id,"network1","fred")
     assert_equal 404, http_error
@@ -469,7 +469,7 @@ class NetworkBarclampTest < ActiveSupport::TestCase
   # Enable interface success - perfect path
   test "network_enable_interface: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = Node.new(:name => "fred.flintstone.org")
     node.save!

--- a/crowbar_engine/barclamp_network/test/unit/network_model_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/network_model_test.rb
@@ -20,7 +20,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Successful create
   test "Network creation: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -30,7 +30,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Successful delete
   test "Network deletion: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -76,7 +76,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # name does not exist
   test "Network creation: failure due to missing name" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = BarclampNetwork::Network.new()
     network.dhcp_enabled = true
@@ -92,7 +92,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # dhcp_enabled does not exist
   test "Network creation: failure due to missing dhcp_enabled" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = BarclampNetwork::Network.new
     network.name = "fred"
@@ -108,7 +108,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # subnet does not exist
   test "Network creation: failure due to missing subnet" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = BarclampNetwork::Network.new
     network.name = "fred"
@@ -124,7 +124,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # no ip_ranges specified
   test "Network creation: failure due to no ip_ranges" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = BarclampNetwork::Network.new
     network.name = "fred"
@@ -140,7 +140,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Test cascade Vlan deletion on Network deletion
   test "Network deletion: cascade delete to Vlans" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.vlan = BarclampNetwork::Vlan.new(:tag => 100)
@@ -157,7 +157,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Test ip alloc failure due to no range
   test "Network allocate ip: failure due to no range" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -173,7 +173,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Test ip alloc failure due to no node
   test "Network allocate ip: failure due to no node" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -186,7 +186,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Test ip alloc success due to node already has an ip
   test "Network allocate_ip: success due to node already has allocated IP" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = Node.new(:name => "fred.flintstone.org")
     node.save!
@@ -211,7 +211,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Test ip alloc success due to suggested ip ok
   test "Network allocate_ip: success due to suggested IP being available" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     ip_address = "192.168.122.3"
     node = Node.new(:name => "fred.flintstone.org")
@@ -231,7 +231,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Test ip alloc success
   test "Network allocate_ip: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = Node.new(:name => "fred.flintstone.org")
     node.save!
@@ -252,7 +252,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Test ip alloc success when suggested ip already allocated
   test "Network allocate_ip: success due to suggested IP unavailable" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -276,7 +276,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Test ip alloc failure due to out of addresses
   test "Network allocate_ip: failure due to out of addresses" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -298,7 +298,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Deallocate IP failure due to missing node
   test "Network deallocate_ip: failure due to missing node" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
     network.save!
@@ -311,7 +311,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Deallocate IP success due to no IP allocated to node
   test "Network deallocate_ip: success due to no IP allocated" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = Node.new(:name => "fred.flintstone.org")
     node.save!
@@ -331,7 +331,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Deallocate IP success - perfect path
   test "Network deallocate_ip: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = Node.new(:name => "fred.flintstone.org")
     node.save!
@@ -356,7 +356,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   # Enable interface success due to no existing interface
   test "Network enable_ip: success" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     node = Node.new(:name => "fred.flintstone.org")
     node.save!
@@ -373,7 +373,7 @@ class NetworkModelTest < ActiveSupport::TestCase
   test "Network enable_ip: success due to existing interface" do
     barclamp = NetworkTestHelper.create_a_barclamp()
     barclamp.save!
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
     deployment.save!
 
     node = Node.new(:name => "fred.flintstone.org")

--- a/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
@@ -26,17 +26,17 @@ class NetworkUtilsTest < ActiveSupport::TestCase
   # Return nil if no active snapshot was found
   test "find_network: return nil if no active snapshot found" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     http_error, result = BarclampNetwork::NetworkUtils.find_network("fred", deployment.id, BarclampNetwork::NetworkUtils::ACTIVE_SNAPSHOT)
     assert_equal 404, http_error, result
   end
 
 
-  # Failure to find network due to bad network id when proposal unspecified
+  # Failure to find network due to bad network id
   test "find_network: failure to find network due to bad network id" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     http_error, result = BarclampNetwork::NetworkUtils.find_network("fred", deployment.id)
     assert_equal 404, http_error, result
@@ -46,7 +46,7 @@ class NetworkUtilsTest < ActiveSupport::TestCase
   # Consistency check of snapshot id given network DB id
   test "find_network: consistency check of network id failure" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment)
 
@@ -66,7 +66,7 @@ class NetworkUtilsTest < ActiveSupport::TestCase
   # Successfully find network when only network name supplied
   test "find_network: success when only network name supplied" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment, "public")
     network.save!
@@ -82,7 +82,7 @@ class NetworkUtilsTest < ActiveSupport::TestCase
   # Successfully find network when network name and Deployment supplied
   test "find_network: success when network name and Deployment supplied" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment, "public")
     network.save!
@@ -97,7 +97,7 @@ class NetworkUtilsTest < ActiveSupport::TestCase
   # Successfully find network when network name, Deployment, and proposed type supplied
   test "find_network: success when network name, Deployment, and proposed supplied" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
 
     network = NetworkTestHelper.create_a_network(deployment, "public")
     network.save!

--- a/crowbar_engine/barclamp_network/test/unit/role_filter_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/role_filter_test.rb
@@ -17,7 +17,7 @@ require 'test_helper'
 class RoleFilterTest < ActiveSupport::TestCase
   test "Test successful match" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
     snapshot = deployment.proposed_snapshot
 
     cf = BarclampNetwork::RoleFilter.new()
@@ -35,7 +35,7 @@ class RoleFilterTest < ActiveSupport::TestCase
 
   test "Test unsuccessful match" do
     barclamp = NetworkTestHelper.create_a_barclamp()
-    deployment = barclamp.create_proposal()
+    deployment = barclamp.create_or_get_deployment()
     snapshot = deployment.proposed_snapshot
 
     cf = BarclampNetwork::RoleFilter.new()


### PR DESCRIPTION
This pull causes the default network deployment to be created in a DB migration.
This will allow running the network BDD tests in the dev test environment.

 .../app/models/barclamp_network/barclamp.rb        |   17 +++++--
 .../db/migrate/20130312110000_create_deployment.rb |   32 ++++++++++++
 .../test/unit/allocated_ip_address_model.rb        |   18 +++----
 .../test/unit/attrib_bus_order_test.rb             |    2 +-
 .../test/unit/attrib_ip_address_test.rb            |    4 +-
 .../test/unit/conduit_rule_test.rb                 |   10 ++--
 .../barclamp_network/test/unit/conduit_test.rb     |    8 +--
 .../test/unit/interface_map_model_test.rb          |    8 +--
 .../test/unit/interface_model_test.rb              |    2 +-
 .../test/unit/network_barclamp_test.rb             |   52 ++++++++++----------
 .../test/unit/network_model_test.rb                |   38 +++++++-------
 .../test/unit/network_utils_test.rb                |   14 +++---
 .../barclamp_network/test/unit/role_filter_test.rb |    4 +-
 13 files changed, 126 insertions(+), 83 deletions(-)

Crowbar-Pull-ID: 3a8d147f4aa7ee2677d69819f97dd5cbd923fdce

Crowbar-Release: development
