### PR TITLE
Adding logging to debug Travis-only unit test issue [1/1]

### DIFF
--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/network_utils.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/network_utils.rb
@@ -31,7 +31,13 @@ class BarclampNetwork::NetworkUtils
       # The deployment_id must be a name, and deployment names are only unique
       # within a given barclamp, so first get the barclamp
       barclamp = BarclampNetwork::Barclamp.find_key(BarclampNetwork::Barclamp::BARCLAMP_NAME)
+      puts("\nLooking for deployment where barclamp_id=#{barclamp.id}, and name=#{deployment_id}\n")
       deployment = Deployment.where("barclamp_id = ? AND name = ?", barclamp.id, deployment_id).first
+      if deployment.nil?
+        puts("\nNo deployment found\n")
+      else
+        puts("\nDeployment #{deployment.id}/#{deployment.name} found\n")
+      end
     end
 
     return [404, "There is no Deployment with id #{deployment_id}"] if deployment.nil?

--- a/crowbar_engine/barclamp_network/db/migrate/20130312110000_create_deployment.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20130312110000_create_deployment.rb
@@ -22,7 +22,8 @@
 class CreateDeployment < ActiveRecord::Migration
   def self.up
     barclamp = BarclampNetwork::Barclamp.find_key(BarclampNetwork::Barclamp::BARCLAMP_NAME)
-    barclamp.create_deployment("Default")
+    deployment = barclamp.create_deployment("Default")
+    puts("\nCreated deployment #{deployment.id}/#{deployment.name}\n")
   end
 
   def self.down

--- a/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
@@ -45,8 +45,10 @@ class NetworkUtilsTest < ActiveSupport::TestCase
 
   # Consistency check of snapshot id given network DB id
   test "find_network: consistency check of network id failure" do
+    puts("\nStarting find_network: consistency check of network id failure\n")
     barclamp = NetworkTestHelper.create_a_barclamp()
     deployment = barclamp.create_or_get_deployment()
+    puts("\nRetrieved deployment #{deployment.id}/#{deployment.name}\n")
 
     network = NetworkTestHelper.create_a_network(deployment)
 
@@ -59,19 +61,23 @@ class NetworkUtilsTest < ActiveSupport::TestCase
     network.save!
 
     http_error, network = BarclampNetwork::NetworkUtils.find_network(network.id)
+    puts("\nEvaluating test results\n")
     assert_equal 400, http_error, network
   end
 
 
   # Successfully find network when only network name supplied
   test "find_network: success when only network name supplied" do
+    puts("\nStarting find_network: success when only network name supplied\n")
     barclamp = NetworkTestHelper.create_a_barclamp()
     deployment = barclamp.create_or_get_deployment()
+    puts("\nRetrieved deployment #{deployment.id}/#{deployment.name}\n")
 
     network = NetworkTestHelper.create_a_network(deployment, "public")
     network.save!
 
     http_error, network = BarclampNetwork::NetworkUtils.find_network("public")
+    puts("\nEvaluating test results\n")
 
     assert_equal 200, http_error, "Return code of 200 expected, got #{http_error}: #{network}"
     assert_not_nil network


### PR DESCRIPTION
Adding puts logging to debug Travis-only unit test issue

 .../app/models/barclamp_network/network_utils.rb   |    6 ++++++
 .../db/migrate/20130312110000_create_deployment.rb |    3 ++-
 .../test/unit/network_utils_test.rb                |    6 ++++++
 3 files changed, 14 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 2d11376fbb1ce4a5aad2e1a856b267bfa4e8f2ca

Crowbar-Release: development
