### PR TITLE
Fixing latest Travis build error [1/1]

### DIFF
--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/attrib_ip_address.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/attrib_ip_address.rb
@@ -34,7 +34,7 @@ class BarclampNetwork::AttribIpAddress < Attrib
   end
   
 
-  def actual(network_id="admin", deployment_id=Barclamp::DEFAULT_DEPLOYMENT_NAME,
+  def actual(network_id="admin", deployment_id=BarclampNetwork::Barclamp::DEPLOYMENT_NAME,
              snapshot_type=BarclampNetwork::NetworkUtils::ACTIVE_SNAPSHOT)
     error_code, result = BarclampNetwork::NetworkUtils.find_network(
         network_id,
@@ -53,7 +53,7 @@ class BarclampNetwork::AttribIpAddress < Attrib
   end
 
 
-  def value(network_id="admin", deployment_id=Barclamp::DEFAULT_DEPLOYMENT_NAME,
+  def value(network_id="admin", deployment_id=BarclampNetwork::Barclamp::DEPLOYMENT_NAME,
              snapshot_type=BarclampNetwork::NetworkUtils::ACTIVE_SNAPSHOT)
     return self.actual(network_id, deployment_id, snapshot_type)
   end

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/barclamp.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/barclamp.rb
@@ -20,6 +20,7 @@ class BarclampNetwork::Barclamp < Barclamp
 
 
   BARCLAMP_NAME = "network"
+  DEPLOYMENT_NAME = "default"
 
 
   def create_deployment(deployment_name=nil)

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/network_utils.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/network_utils.rb
@@ -20,7 +20,7 @@ class BarclampNetwork::NetworkUtils
 
   def self.find_network(
       network_id,
-      deployment_id = Barclamp::DEFAULT_DEPLOYMENT_NAME,
+      deployment_id = BarclampNetwork::Barclamp::DEPLOYMENT_NAME,
       snapshot_type = PROPOSED_SNAPSHOT)
 
     # If the passed deployment_id is a DB ID then...
@@ -31,13 +31,7 @@ class BarclampNetwork::NetworkUtils
       # The deployment_id must be a name, and deployment names are only unique
       # within a given barclamp, so first get the barclamp
       barclamp = BarclampNetwork::Barclamp.find_key(BarclampNetwork::Barclamp::BARCLAMP_NAME)
-      puts("\nLooking for deployment where barclamp_id=#{barclamp.id}, and name=#{deployment_id}\n")
       deployment = Deployment.where("barclamp_id = ? AND name = ?", barclamp.id, deployment_id).first
-      if deployment.nil?
-        puts("\nNo deployment found\n")
-      else
-        puts("\nDeployment #{deployment.id}/#{deployment.name} found\n")
-      end
     end
 
     return [404, "There is no Deployment with id #{deployment_id}"] if deployment.nil?

--- a/crowbar_engine/barclamp_network/db/migrate/20130312110000_create_deployment.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20130312110000_create_deployment.rb
@@ -22,7 +22,7 @@
 class CreateDeployment < ActiveRecord::Migration
   def self.up
     barclamp = BarclampNetwork::Barclamp.find_key(BarclampNetwork::Barclamp::BARCLAMP_NAME)
-    deployment = barclamp.create_deployment("Default")
+    deployment = barclamp.create_deployment(BarclampNetwork::Barclamp::DEPLOYMENT_NAME)
     puts("\nCreated deployment #{deployment.id}/#{deployment.name}\n")
   end
 

--- a/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/network_utils_test.rb
@@ -45,10 +45,8 @@ class NetworkUtilsTest < ActiveSupport::TestCase
 
   # Consistency check of snapshot id given network DB id
   test "find_network: consistency check of network id failure" do
-    puts("\nStarting find_network: consistency check of network id failure\n")
     barclamp = NetworkTestHelper.create_a_barclamp()
     deployment = barclamp.create_or_get_deployment()
-    puts("\nRetrieved deployment #{deployment.id}/#{deployment.name}\n")
 
     network = NetworkTestHelper.create_a_network(deployment)
 
@@ -61,23 +59,19 @@ class NetworkUtilsTest < ActiveSupport::TestCase
     network.save!
 
     http_error, network = BarclampNetwork::NetworkUtils.find_network(network.id)
-    puts("\nEvaluating test results\n")
     assert_equal 400, http_error, network
   end
 
 
   # Successfully find network when only network name supplied
   test "find_network: success when only network name supplied" do
-    puts("\nStarting find_network: success when only network name supplied\n")
     barclamp = NetworkTestHelper.create_a_barclamp()
     deployment = barclamp.create_or_get_deployment()
-    puts("\nRetrieved deployment #{deployment.id}/#{deployment.name}\n")
 
     network = NetworkTestHelper.create_a_network(deployment, "public")
     network.save!
 
     http_error, network = BarclampNetwork::NetworkUtils.find_network("public")
-    puts("\nEvaluating test results\n")
 
     assert_equal 200, http_error, "Return code of 200 expected, got #{http_error}: #{network}"
     assert_not_nil network


### PR DESCRIPTION
Fixing the latest Travis error in the network barclamp where translations is not working when running the unit tests.
This pull does not fix that problem, but works around it by not using translation for the network barclamp default deployment name.

 .../models/barclamp_network/attrib_ip_address.rb   |    4 ++--
 .../app/models/barclamp_network/barclamp.rb        |    1 +
 .../app/models/barclamp_network/network_utils.rb   |    8 +-------
 .../db/migrate/20130312110000_create_deployment.rb |    2 +-
 .../test/unit/network_utils_test.rb                |    6 ------
 5 files changed, 5 insertions(+), 16 deletions(-)

Crowbar-Pull-ID: b919470a9dc3426a99b0b4b15dba8ce281de6105

Crowbar-Release: development
