### PR TITLE
Fixes to tests and deployments now that we have the correct test database [2/2]

### DIFF
--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/barclamp.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/barclamp.rb
@@ -18,9 +18,7 @@ class BarclampNetwork::Barclamp < Barclamp
     allow_multiple_proposals = false
   end
 
-
-  BARCLAMP_NAME = "network"
-  DEPLOYMENT_NAME = "default"
+  DEPLOYMENT_NAME = Barclamp::DEFAULT_DEPLOYMENT_NAME
 
 
   def create_deployment(deployment_name=nil)

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/network_utils.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/network_utils.rb
@@ -93,7 +93,7 @@ class BarclampNetwork::NetworkUtils
     else
       # The deployment_id must be a name, and deployment names are only unique
       # within a given barclamp, so first get the barclamp
-      barclamp = BarclampNetwork::Barclamp.find_key(BarclampNetwork::Barclamp::BARCLAMP_NAME)
+      barclamp = BarclampNetwork::Barclamp.first
       deployment = Deployment.where("barclamp_id = ? AND name = ?", barclamp.id, deployment_id).first     
     end
     deployment

--- a/crowbar_engine/barclamp_network/db/migrate/20130312110000_create_deployment.rb
+++ b/crowbar_engine/barclamp_network/db/migrate/20130312110000_create_deployment.rb
@@ -21,8 +21,8 @@
 
 class CreateDeployment < ActiveRecord::Migration
   def self.up
-    barclamp = BarclampNetwork::Barclamp.find_key(BarclampNetwork::Barclamp::BARCLAMP_NAME)
-    deployment = barclamp.create_deployment(BarclampNetwork::Barclamp::DEPLOYMENT_NAME)
+    barclamp = BarclampNetwork::Barclamp.first
+    deployment = barclamp.default_deployment(true)
     puts("\nCreated deployment #{deployment.id}/#{deployment.name}\n")
   end
 

--- a/crowbar_engine/barclamp_network/test/network_test_helper.rb
+++ b/crowbar_engine/barclamp_network/test/network_test_helper.rb
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and 
 # limitations under the License. 
 
+require 'rails/test_help'
+require 'test_helper'
+
 class NetworkTestHelper
   DEFAULT_NETWORK_NAME = "bedrock"
 
@@ -165,18 +168,8 @@ class NetworkTestHelper
 
 
   def self.create_a_barclamp()
-    barclamp = BarclampNetwork::Barclamp.find_key(BarclampNetwork::Barclamp::BARCLAMP_NAME)
-    if barclamp.nil?
-      barclamp = BarclampNetwork::Barclamp.new(:name => BarclampNetwork::Barclamp::BARCLAMP_NAME)
-      barclamp.save!
-
-      snapshot = Snapshot.new()
-      snapshot.barclamp = barclamp
-      snapshot.save!
-
-      barclamp.template = snapshot
-      barclamp.save!
-    end
+    barclamp = BarclampNetwork::Barclamp.first
+    raise "you must have the network barclamp!" unless barclamp
     barclamp
   end
 end


### PR DESCRIPTION
This pull tightens the testing for barclamps because there was a dev error building the test database.
Consequently, it depends on pull request 

The pull also has the first working Deployment dependency code.  This code is called when the 
barclamp.proposal_create override is called.

 .../app/models/barclamp_network/barclamp.rb        |    4 +---
 .../app/models/barclamp_network/network_utils.rb   |    2 +-
 .../db/migrate/20130312110000_create_deployment.rb |    4 ++--
 .../barclamp_network/test/network_test_helper.rb   |   17 +++++------------
 4 files changed, 9 insertions(+), 18 deletions(-)

Crowbar-Pull-ID: 4ed3a472668365dfb9125a765ed0332fdad712f5

Crowbar-Release: development
