### PR TITLE
Adding custom attrib to expose interface map [1/1]

### DIFF
--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/attrib_configured_interface_map.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/attrib_configured_interface_map.rb
@@ -1,0 +1,48 @@
+# Copyright 2013, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class BarclampNetwork::AttribConfiguredInterfaceMap < Attrib
+  def state 
+    Attrib.calc_state(value_actual , value_request, jig_run_id)
+  end
+  
+
+  def request=(value)
+    # Discard since this attribute is a facade over AR objects
+    raise "Not implemented"
+  end
+  
+
+  def request
+    raise "Not implemented"
+  end
+  
+
+  def actual=(value)
+    # Discard since this attribute is a facade over AR objects
+  end
+  
+
+  def actual(deployment_id=BarclampNetwork::Barclamp::DEPLOYMENT_NAME)
+    interface_map = BarclampNetwork::InterfaceMap.get_interface_map(deployment_id)
+
+    network = {}
+    network["interface_map"] = interface_map.get_configured_bus_order()
+
+    blob_to_publish = {}
+    blob_to_publish["network"] = network
+
+    blob_to_publish.to_json
+  end
+end

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/barclamp.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/barclamp.rb
@@ -42,6 +42,26 @@ class BarclampNetwork::Barclamp < Barclamp
   end
 
 
+  def process_inbound_data(jig_run, node, data)
+    # Create a standard attrib for each blob of json
+    detected_network_blob = data[:crowbar_ohai][:detected][:network]
+
+    Rails.logger.debug("Discovered the following nics for node #{node.name}")
+    Rails.logger.debug("#{detected_network_blob}")
+
+    network = {}
+    network[:network] = detected_network_blob
+
+    detected = {}
+    detected[:detected] = network
+
+    blob_to_publish = {}
+    blob_to_publish[:crowbar_ohai] = detected
+
+    Attrib.create!(:name => "detected_networks", :value => blob_to_publish)
+  end
+
+
   def network_allocate_ip(deployment_id, network_id, range, node_id, suggestion = nil)
     Rails.logger.debug("Entering allocate_ip(deployment_id: #{deployment_id}, network_id: #{network_id}, range: #{range}, node_id: #{node_id}, suggestion: #{suggestion})")
 

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/bus_map.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/bus_map.rb
@@ -20,4 +20,18 @@ class BarclampNetwork::BusMap < ActiveRecord::Base
 
   validates :pattern, :presence => true
   validates :buses, :presence => true
+
+
+  def get_configured_bus_map()
+    bus_map = {}
+    bus_map["pattern"] = self.pattern
+
+    bus_order = {}
+    buses.each { |bus|
+      bus_order[bus.order.to_s] = bus.path
+    }
+
+    bus_map["bus_order"] = bus_order
+    bus_map
+  end
 end

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/interface_map.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/interface_map.rb
@@ -33,4 +33,26 @@ class BarclampNetwork::InterfaceMap < ActiveRecord::Base
     buses.sort! {|bus1,bus2| bus1.order.to_i <=> bus2.order.to_i} if !buses.nil?
     buses
   end
+
+
+  # This method converts the InterfaceMap into raw json
+  def self.get_interface_map(deployment_id=BarclampNetwork::Barclamp::DEPLOYMENT_NAME)
+    deployment = BarclampNetwork::NetworkUtils.find_deployment(deployment_id)
+    raise "There is no deployment with a deployment_id of #{deployment_id}" if deployment.nil?
+
+    BarclampNetwork::InterfaceMap.joins(:snapshot).where("snapshots" => {:deployment_id => deployment.id})[0]
+  end
+
+
+  def get_configured_interface_map()
+    interface_map_hash = {}
+
+    index = 0
+    bus_maps.each { |bus_map|
+      interface_map_hash[index.to_s] = bus_map.get_configured_bus_map()
+      index += 1
+    }
+
+    interface_map_hash
+  end
 end

--- a/crowbar_engine/barclamp_network/test/network_test_helper.rb
+++ b/crowbar_engine/barclamp_network/test/network_test_helper.rb
@@ -116,9 +116,14 @@ class NetworkTestHelper
     interface_map
   end
   
+
+  DEFAULT_PATTERN = "PowerEdge C6145"
+  DEFAULT_PATH0 = "0000:00/0000:00:04"
+  DEFAULT_PATH1 = "0000:00/0000:00:02"
   
+
   # Create a bus map
-  def self.create_a_bus_map(pattern="PowerEdge C6145", bus_order={ "0" => "0000:00/0000:00:04", "1" => "0000:00/0000:00:02"})
+  def self.create_a_bus_map(pattern=DEFAULT_PATTERN, bus_order={ "0" => DEFAULT_PATH0, "1" => DEFAULT_PATH1})
     bus_map = BarclampNetwork::BusMap.new( :pattern => pattern)
     bus_map.buses << create_buses(bus_order)
     bus_map

--- a/crowbar_engine/barclamp_network/test/unit/bus_map_model_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/bus_map_model_test.rb
@@ -53,4 +53,20 @@ class BusMapModelTest < ActiveSupport::TestCase
       BarclampNetwork::Bus.find(bus_id)
     end
   end
+
+
+  test "BusMap get_configured_bus_map" do
+    bus_map = NetworkTestHelper.create_a_bus_map()
+    bus_map.save!
+
+    configured_bus_map = bus_map.get_configured_bus_map()
+    assert_equal NetworkTestHelper::DEFAULT_PATTERN, configured_bus_map["pattern"]
+
+    configured_bus_order = configured_bus_map["bus_order"]
+    assert !configured_bus_order.nil?
+    assert_equal 2, configured_bus_order.size
+
+    assert_equal NetworkTestHelper::DEFAULT_PATH0, configured_bus_order["0"]
+    assert_equal NetworkTestHelper::DEFAULT_PATH1, configured_bus_order["1"]
+  end
 end

--- a/crowbar_engine/barclamp_network/test/unit/interface_map_model_test.rb
+++ b/crowbar_engine/barclamp_network/test/unit/interface_map_model_test.rb
@@ -87,4 +87,56 @@ class InterfaceMapModelTest < ActiveSupport::TestCase
     buses = BarclampNetwork::InterfaceMap.get_bus_order(node)
     assert_nil buses
   end
+
+
+  test "InterfaceMap: get_configured_interface_map success" do
+    barclamp = NetworkTestHelper.create_a_barclamp()
+    deployment = barclamp.create_or_get_deployment()
+
+    interface_map = NetworkTestHelper.create_an_interface_map(deployment)
+    interface_map.save!
+
+    configured_interface_map = interface_map.get_configured_interface_map()
+
+    assert !configured_interface_map.nil?
+    assert_equal 2, configured_interface_map.size
+
+    bus_map0 = configured_interface_map["0"]
+    bus_map1 = configured_interface_map["1"]
+
+    if bus_map0["pattern"] == "PowerEdge C6145"
+      pe_6145_bus_map = bus_map0
+      pe_710_bus_map = bus_map1
+    else
+      pe_6145_bus_map = bus_map1
+      pe_710_bus_map = bus_map0
+    end
+
+    assert_equal "PowerEdge C6145", pe_6145_bus_map["pattern"]
+    assert_equal "0000:00/0000:00:04", pe_6145_bus_map["bus_order"]["0"]
+    assert_equal "0000:00/0000:00:02", pe_6145_bus_map["bus_order"]["1"]
+
+    assert "PowerEdge R710", pe_710_bus_map["pattern"]
+    assert_equal "0000:00/0000:00:01", pe_710_bus_map["bus_order"]["0"]
+    assert_equal "0000:00/0000:00:03", pe_710_bus_map["bus_order"]["1"]
+  end
+
+
+  test "InterfaceMap: get_interface_map failure due to bad deployment_id" do
+    assert_raise RuntimeError do
+      BarclampNetwork::InterfaceMap.get_interface_map("fred")
+    end
+  end
+
+
+  test "InterfaceMap: get_interface_map success" do
+    barclamp = NetworkTestHelper.create_a_barclamp()
+    deployment = barclamp.create_or_get_deployment()
+
+    interface_map = NetworkTestHelper.create_an_interface_map(deployment)
+    interface_map.save!
+
+    interface_map = BarclampNetwork::InterfaceMap.get_interface_map(deployment.name)
+    assert !interface_map.nil?
+  end
 end


### PR DESCRIPTION
Added custom attrib to expose interface map.
Added discovery piece of network barclamp.

 .../attrib_configured_interface_map.rb             |   48 ++++++++++++++++++
 .../app/models/barclamp_network/barclamp.rb        |   20 ++++++++
 .../app/models/barclamp_network/bus_map.rb         |   14 ++++++
 .../app/models/barclamp_network/interface_map.rb   |   22 +++++++++
 .../barclamp_network/test/network_test_helper.rb   |    7 ++-
 .../test/unit/bus_map_model_test.rb                |   16 ++++++
 .../test/unit/interface_map_model_test.rb          |   52 ++++++++++++++++++++
 7 files changed, 178 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 1a70ced1ba4b1ec4d35a538ee93d40d9723c1895

Crowbar-Release: development
