### PR TITLE
Goodbye, RoleType. [2/2]

### DIFF
--- a/crowbar_engine/barclamp_network/test/network_test_helper.rb
+++ b/crowbar_engine/barclamp_network/test/network_test_helper.rb
@@ -149,9 +149,7 @@ class NetworkTestHelper
 
 
   def self.add_role(snapshot, node, role_name)
-    role_type = RoleType.create!(:name=>role_name)
-
-    role = Role.create!(:role_type_id => role_type.id, :snapshot_id => snapshot.id)
+    role = Role.create!(:name => role_name, :snapshot_id => snapshot.id)
     role.add_node(node)
   end
 


### PR DESCRIPTION
Zap role_types.  They were not being used for any purpose other than
to have a different place to name a role that was not being kept in
sync with the roles table, and the codebase dealing with roles is
simpler without having them around.

 .../barclamp_network/test/network_test_helper.rb   |    4 +---
 1 file changed, 1 insertion(+), 3 deletions(-)

Crowbar-Pull-ID: f5766c096e030450e3b5195fbf0241607e78a313

Crowbar-Release: development
