### PR TITLE
Backport the network recipies from Crowbar 2.0 [3/3]

### DIFF
--- a/chef/cookbooks/network/metadata.rb
+++ b/chef/cookbooks/network/metadata.rb
@@ -1,0 +1,6 @@
+maintainer       "Dell Crowbar Team"
+maintainer_email "openstack@dell.com"
+license          "Apache 2"
+description      "Network configuration and management for Chef and Crowbar"
+long_description "Network configuration and management for Chef and Crowbar"
+version          "0.9.5"

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -1,4 +1,5 @@
-# Copyright 2011, Dell
+# Copyright 2013, Dell
+# Copyright 2012, SUSE Linux Products GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,528 +14,335 @@
 # limitations under the License.
 #
 
-include_recipe 'utils'
-
-$bond_count = 0
-team_mode = node["network"]["teaming"]["mode"]
-
-# Walk through a hash of interfaces, adding :order tags to each
-# interface that reflects the order in which they should be brought up in.
-# They should be torn down in reverse order. 
-def sort_interfaces(interfaces)
-  seq=0
-  i=interfaces.keys.sort
-  until i.empty?
-    i.each do |ifname|
-      iface=interfaces[ifname]
-      iface[:interface_list] ||= Array.new
-      iface[:interface_list] = iface[:interface_list].sort
-      # If this interface has children, and any of its children have not
-      # been given a sequence number, skip it.
-      next if not iface[:interface_list].empty? and 
-          not iface[:interface_list].all? {|j| interfaces[j].has_key?(:order)}
-      iface[:order] = seq
-      seq=seq + 1
-    end
-    unless i.any? {|j| interfaces[j][:order]}
-      raise ::RangeError.new("Interfaces #{i.inspect} touched, but no sequence numbers assigned!\nThis should never happen.")
-    end 
-    i=interfaces.keys.sort.reject{|k| interfaces[k].has_key?(:order)}
-  end
-  interfaces
-end
-
-# Parse the contents of /etc/network/interfaces, and return a data structure
-# equivalent to the one we get from Chef.
-def local_debian_interfaces
-  res={}
-  iface=''
-  File.foreach("/etc/network/interfaces") {|line|
-    line = line.chomp.strip.split('#')[0] # strip comments
-    next if line.nil? or ( line.length == 0 ) # skip blank lines
-    parts = line.split
-    case parts[0]
-    when "auto"
-      parts[1..-1].each { |name|
-        next if name == "lo"
-        res[name] ||= Hash.new
-        res[name][:auto] = true
-        res[name][:interface] ||= name
-      }
-    when "iface"
-      iface = parts[1]
-      next if iface == "lo"
-      res[iface] ||= Hash.new 
-      res[iface][:interface] = iface
-      res[iface][:interface_list] ||= []
-      res[iface][:config] = parts[3]
-    when "address" then res[iface][:ipaddress] = parts[1]
-    when "netmask" then res[iface][:netmask] = parts[1]
-    when "broadcast" then res[iface][:broadcast] = parts[1]
-    when "gateway" then res[iface][:router] = parts[1]
-    when "mtu" then res[iface][:mtu] = parts[1]
-    when "bridge_ports" then 
-      res[iface][:mode] = "bridge"
-      res[iface][:interface_list] = parts[1..-1]
-      res[iface][:interface_list].each do |i|
-        res[i] ||= Hash.new
-        res[i][:bridge]=iface
-      end
-    when "vlan_raw_device" then
-      res[iface][:mode] = "vlan"
-      res[iface][:vlan] = iface.split('.',2)[1].to_i
-      res[iface][:interface_list] = Array[ parts[1] ]
-    when "down" then 
-      res[iface][:mode] = "team"
-      res[iface][:interface_list] = parts[4..-1]
-      res[iface][:interface_list].each do |i|
-        res[i] ||= Hash.new
-        res[i][:master]=iface
-        res[i][:slave]=true
-      end
-    end
-  }
-  sort_interfaces(res)
-end
-
-def local_redhat_interfaces
-  res = {}
-  ::Dir.entries("/etc/sysconfig/network-scripts").sort.each do |entry|
-    next unless entry =~ /^ifcfg/
-    next if entry == "ifcfg-lo"
-    iface = entry.split('-',2)[1]
-    res[iface] ||= Hash.new
-    ::File.foreach("/etc/sysconfig/network-scripts/#{entry}") do |line|
-      line = line.chomp.strip.split('#')[0] # strip comments
-      next if line.nil? or ( line.length == 0 ) # skip blank lines
-      parts = line.split('=',2)
-      k=parts[0]
-      v=parts[1][/\A"(.*)"\z/m,1]  # Remove start/end quotes from the string
-      v=parts[1] if v.nil?
-      case k
-      when "DEVICE" then res[iface][:interface]=v
-      when "ONBOOT" 
-        res[iface][:auto] = true when v == "yes"
-      when "BOOTPROTO" then res[iface][:config] = v
-      when "MTU" then res[iface][:mtu] = v
-      when "IPADDR"
-        res[iface][:ipaddress] = v
-      when "NETMASK" then res[iface][:netmask] = v
-      when "BROADCAST" then res[iface][:broadcast] = v
-      when "BONDING_OPTS" then res[iface][:bond_opts] = v
-      when "GATEWAY" then res[iface][:router] = v
-      when "MASTER" 
-        res[iface][:master] = v
-        res[v] ||= Hash.new
-        res[v][:mode] = "team"
-        res[v][:interface_list] ||= Array.new
-        res[v][:interface_list].push(iface)
-      when "SLAVE"
-        res[iface][:slave] = true if v == "yes"
-      when "BRIDGE"
-        res[iface][:bridge] = v
-        res[v] ||= Hash.new
-        res[v][:mode] = "bridge"
-        res[v][:interface_list] ||= Array.new 
-        res[v][:interface_list].push(iface)
-      when "VLAN"
-        res[iface][:mode] = "vlan"
-        res[iface][:vlan] = iface.split('.',2)[1].to_i
-        res[iface][:interface_list]=[iface.split('.',2)[0]]
-      end
-    end
-    if res[iface][:config] == "none"
-      res[iface][:config] = if res[iface][:ipaddress]
-                              "static"
-                            else
-                              "manual"
-                            end
-    end
-    res[iface][:auto] = false unless res[iface][:auto]
-  end
-  sort_interfaces(res)
-end
-
-def crowbar_interfaces()
-  conduit_map = Barclamp::Inventory.build_node_map(node)
-  Chef::Log.info("Conduit mapping for this node:  #{conduit_map.inspect}")
-  res = Hash.new
-  # seems that we can only have 1 bonding mode is possible per machine
-  machine_team_mode = nil
-  ## find most prefered network to use a default gw
-  max_pref = 10000
-  # name of network prefered as default route - default admin net.
-  net_pref = "admin"
-  node["crowbar"]["network"].each { |name, network | 
-    r_pref = 10000
-    r_pref= Integer(network["router_pref"]) if network["router_pref"]
-    Chef::Log.debug("eval router from #{name}, pref #{r_pref}")
-    if (r_pref < max_pref)
-      max_pref = r_pref
-      net_pref = name
-    end
-  }
-  Chef::Log.info("will allow routers from #{net_pref}")
-  node["crowbar"]["network"].keys.sort.each do |netname|
-    next if netname == "bmc"
-    allow_gw = (netname == net_pref)
-    network=node["crowbar"]["network"][netname]
-
-    conduit = network["conduit"]
-    ## get info about the network:
-    # intf = inteface to be used to carry the network. could be a bond or vlan to be created.
-    # intf_list = array of 1 or more theinterfrace to be used( >1 for bonds)
-    # tm = teaming mdoe for the bond, if any
-    intf, interface_list, tm = Barclamp::Inventory.lookup_interface_info(node, conduit, conduit_map)
-    if intf.nil?
-      Chef::Log.fatal("No conduit for interface: #{conduit}")
-      Chef::Log.fatal("Refusing to do so.")
-      raise ::RangeError.new("No conduit to interface map for #{conduit}")
-    end
-
-    if intf =~ /^bond/
-      tm = team_mode if tm.nil? 
-      machine_team_mode = tm if machine_team_mode.nil?
-      if (!machine_team_mode.nil? and !machine_team_mode == tm)
-          # once a bonding mode has been selected for the machine, don't let others...
-	  Chef::Log.warn("CONFLICTING TEAM MODES: for conduit #{conduit}")
-      end
-      res[intf] ||= Hash.new
-      #capture the network this interface supports
-      res[intf][:associated_network]= netname
-      res[intf][:interface_list] = interface_list
-      unless interface_list && ! interface_list.empty?
-        raise ::RangeError.new("No slave interfaces for #{intf}")
-      end
-      res[intf][:mode] = "team"
-      res[intf][:interface] = intf
-      # Bond opts is only needed and built for redhat.
-      case node[:platform]
-      when "ubuntu","debian"
-        # No-op
-      when "centos","redhat"
-        res[intf][:bond_opts] = "mode=#{tm} miimon=100"
-      end
-      # Since we are making a team out of these devices, blow away whatever
-      # config we may have had for the slaves.
-      res[intf][:interface_list].each do |i|
-        res[i]=Hash.new
-        res[i][:interface]=i
-        res[i][:auto]=true
-        res[i][:config]="manual"
-        res[i][:slave]=true
-        res[i][:master]=intf
-      end
-      interface_list = [ intf ]
-    end
-
-    # Handle vlans first.
-    if network["use_vlan"]
-      intf = "#{intf}.#{network["vlan"]}"
-      res[intf] ||= Hash.new
-      #capture the network this interface supports
-      res[intf][:associated_network]= netname
-      res[intf][:interface] = intf
-      res[intf][:auto] = true
-      res[intf][:vlan] = network["vlan"]
-      res[intf][:mode] = "vlan"
-      res[intf][:interface_list] = interface_list
-      res[intf][:interface_list].each do |i|
-        unless res[i]
-          res[i] = Hash.new
-          res[i][:interface] = i
-          res[i][:auto] = true
-          res[i][:config] = "manual" if res[i][:ipaddress].nil?
-        end
-      end
-    else
-      res[intf] ||= Hash.new
-      #capture the network this interface supports
-      res[intf][:associated_network]= netname
-      res[intf][:interface] = intf
-      res[intf][:auto] = true
-    end
-    # If we were asked to make a bridge, do it second.
-    if network["add_bridge"]
-      # We have to make up a bridge name here
-      res[intf][:bridge]=if res[intf][:vlan] 
-                           "br#{res[intf][:vlan]}"
-                         else
-                           "br#{intf}"
-                         end
-      # That base interface now has a manual config
-      res[intf][:config]="manual"
-      base_if=intf
-      intf=res[intf][:bridge]
-      res[intf] ||= Hash.new
-      #capture the network this interface supports
-      res[intf][:associated_network]= netname
-      res[intf][:interface] = intf
-      res[intf][:interface_list] = [ base_if ]
-      res[intf][:auto] = true
-      res[intf][:mode]="bridge"
-    end
-    if network["address"] and network["address"] != "0.0.0.0"
-      res[intf][:config] = "static"
-      res[intf][:ipaddress] = network["address"]
-      res[intf][:netmask] = network["netmask"]
-      res[intf][:broadcast] = network["broadcast"]
-      res[intf][:router] = network["router"] if network["router"] && allow_gw
-    else
-      res[intf][:config] = "manual"
-    end
-  end  ## crowbar/network loop
-
-  team_mode = machine_team_mode
-  node["network"]["teaming"]["mode"] = team_mode
-  sort_interfaces(res)
-  fixup_mtu(node,node[:crowbar][:network], res)
-
-end
-
-def fixup_mtu(node, networks, intfs)
-  ### fixup MTU for interfaces
-  detected = Barclamp::Inventory.get_detected_intfs(node)
-  mtus = {}
-  intfs.each { |intf_name,intf|
-    next if intf[:slave] # skip enslaved interfaces.
-    net = networks[intf[:associated_network]]
-    mtu =  net["mtu"]
-    # skip if no MTU specified for the network
-    Chef::Log.info("no MTU for network: #{net["usage"]}") && next unless mtu
-
-    base_if = intf[:interface_list][0] rescue nil
-    base_if ||= intf[:interface] rescue nil
-    Chef::Log.info("network: #{net["usage"]}, intf:#{intf.inspect}, base intf: #{base_if}")
-    # if it's not a Gig capable (1g, 10g) interface, skip
-    intf = detected[base_if]
-    Chef::Log.info("intf: #{base_if}, speeds:#{intf[:speeds]}")
-    next unless intf["speeds"].join().index('g')
-    Chef::Log.info("setting: intf:#{intf.inspect}, mtu: #{mtu}")
-    mtus[intf_name] = mtu
-  }
-  mtus.each { |k,v| 
-    intfs[k][:mtu] = v
-  }
-  intfs
-end
-
-
-package "bridge-utils"
-
-## Make sure that ip6tables is off.
-#bash "Make sure ip6tables is off" do
-#  code "/sbin/chkconfig ip6tables off"
-#  only_if "/sbin/chkconfig --list ip6tables | grep -q on"
-#end
-#
-## Make sure that ip6tables service is off
-#bash "Make sure ip6tables service is off" do
-#  code "service ip6tables stop"
-#  not_if "service ip6tables status | grep -q stopped"
-#end
-
-bash "load 8021q module" do
-  code "/sbin/modprobe 8021q"
-  not_if { ::File.exists?("/sys/module/8021q") }
-end
-
-delay = false
-old_interfaces = case node[:platform]
-                 when "debian","ubuntu"
-                   local_debian_interfaces
-                 when "centos","redhat"
-                   local_redhat_interfaces
-                 end
-new_interfaces = crowbar_interfaces
-interfaces_to_up={}
-
+# Make sure packages we need will be present
 case node[:platform]
-when "ubuntu","debian"
-  package "vlan"
-  package "ifenslave-2.6"
-
-  utils_line "8021q" do
-    action :add
-    file "/etc/modules"
-  end
-
-  if node["network"]["mode"] == "team"
-    # make sure to pick up any updates
-    team_mode = node["network"]["teaming"]["mode"]
-    utils_line "bonding mode=#{team_mode} miimon=100" do
-      action :add
-      regexp_exclude "bonding mode=.*"
-      file "/etc/modules"
+when "ubuntu","debian","suse"
+  %w{bridge-utils vlan}.each do |pkg|
+    p = package pkg do
+      action :nothing
     end
-    bash "load bonding module" do
-      code "/sbin/modprobe bonding mode=#{team_mode} miimon=100"
-      not_if { ::File.exists?("/sys/module/bonding") }
-    end
+    p.run_action :install
   end
 when "centos","redhat"
-  package "vconfig"
+  %w{bridge-utils vconfig}.each do |pkg|
+    p = package pkg do
+      action :nothing
+    end
+    p.run_action :install
+  end
+end
 
-  if node["network"]["mode"] == "team"
-    new_interfaces.keys.each do |i|
-      next unless new_interfaces[i][:mode] == "team"
-      utils_line "alias #{i} bonding" do
-        action :add
-        file "/etc/modprobe.conf"
-      end
+if ::File.exists?("/etc/init/network-interface.conf")
+  # Make upstart stop trying to dynamically manage interfaces.
+  ::File.unlink("/etc/init/network-interface.conf")
+  ::Kernel.system("killall -HUP init")
+end
+
+# Stop udev from jacking up our vlans and bridges as we create them.
+["40-bridge-network-interface.rules","40-vlan-network-interface.rules"].each do |rule|
+  next if ::File.exists?("/etc/udev/rules.d/#{rule}")
+  next unless ::File.exists?("/lib/udev/rules.d/#{rule}")
+  ::Kernel.system("echo 'ACTION==\"add\", SUBSYSTEM==\"net\", RUN+=\"/bin/true\"' >/etc/udev/rules.d/#{rule}")
+end
+
+provisioner = search(:node, "roles:provisioner-server")[0]
+conduit_map = Barclamp::Inventory.build_node_map(node)
+Chef::Log.debug("Conduit mapping for this node:  #{conduit_map.inspect}")
+route_pref = 10000
+ifs = Mash.new
+old_ifs = node["crowbar_wall"]["network"]["interfaces"] || Mash.new rescue Mash.new
+if_mapping = Mash.new
+addr_mapping = Mash.new
+default_route = {}
+
+# dhclient running?  Not for long.
+::Kernel.system("killall -w -q -r '^dhclient'")
+
+# Silly little helper for sorting Crowbar networks.
+# Netowrks that use vlans and bridges will be handled later
+def net_weight(net)
+  res = 0
+  if node["crowbar"]["network"][net]["use_vlan"] then res += 1 end
+  if node["crowbar"]["network"][net]["add_bridge"] then res += 1 end
+  res
+end
+
+# Dynamically create our new local interfaces.
+node["crowbar"]["network"].keys.sort{|a,b|
+  net_weight(a) <=> net_weight(b)
+}.each do |name|
+  next if name == "bmc"
+  net_ifs = Array.new
+  network = node["crowbar"]["network"][name]
+  addr = if network["address"]
+           IP.coerce("#{network["address"]}/#{network["netmask"]}")
+         else
+           nil
+         end
+  conduit = network["conduit"]
+  base_ifs = conduit_map[conduit]["if_list"].map{|i| Nic.new(i)}.sort
+  Chef::Log.info("Using base interfaces #{base_ifs.map{|i|i.name}.inspect} for network #{name}")
+  base_ifs.each do |i|
+    ifs[i.name] ||= Hash.new
+    ifs[i.name]["addresses"] ||= Array.new
+    ifs[i.name]["type"] = "physical"
+  end
+  case base_ifs.length
+  when 0
+    Chef::Log.fatal("Conduit #{conduit} does not have any nics. Your config is invalid.")
+    raise ::RangeError.new("Invalid conduit mapping #{conduit_map.inspect}")
+  when 1
+    Chef::Log.info("Using interface #{base_ifs[0]} for network #{name}")
+    our_iface = base_ifs[0]
+  else
+    # We want a bond.  Figure out what mode it should be.  Default to 5
+    team_mode = conduit_map[conduit]["team_mode"] ||
+      (network["teaming"] && network["teaming"]["mode"]) || 5
+    # See if a bond that matches our specifications has already been created,
+    # or if there is an empty bond lying around.
+    bond = Nic.nics.detect do|i|
+      i.kind_of?(Nic::Bond) &&
+        (i.slaves.empty? ||
+         (i.slaves.sort == base_ifs))
+    end
+    if bond
+      Chef::Log.info("Using bond #{bond.name} for network #{name}")
+    else
+      bond = Nic::Bond.create("bond#{Nic.nics.select{|i| Nic::bond?(i)}.length}",
+                       team_mode)
+      Chef::Log.info("Creating bond #{bond.name} for network #{name}")
+    end
+    ifs[bond.name] ||= Hash.new
+    ifs[bond.name]["addresses"] ||= Array.new
+    ifs[bond.name]["slaves"] = Array.new
+    base_ifs.each do |i|
+      bond.add_slave i
+      ifs[bond.name]["slaves"] << i.name
+      ifs[i.name]["slave"] = true
+      ifs[i.name]["master"] = bond.name
+    end
+    ifs[bond.name]["mode"] = team_mode
+    ifs[bond.name]["type"] = "bond"
+    our_iface = bond
+  end
+  net_ifs << our_iface.name
+  # If we want a vlan interface, create one on top of the base physical
+  # interface and/or bond that we already have
+  if network["use_vlan"]
+    vlan = "#{our_iface.name}.#{network["vlan"]}"
+    if Nic.exists?(vlan)
+      Chef::Log.info("Using vlan #{vlan} for network #{name}")
+      our_iface = Nic.new vlan
+    else
+      Chef::Log.info("Creating vlan #{vlan} for network #{name}")
+      our_iface = Nic::Vlan.create(our_iface,network["vlan"])
+    end
+    # Destroy any vlan interfaces for this vlan that might
+    # already exist
+    Nic.nics.each do |n|
+      next unless n.kind_of?(Nic::Vlan)
+      next if n == our_iface
+      next unless n.vlan == network["vlan"].to_i
+      n.destroy
+    end
+    ifs[our_iface.name] ||= Hash.new
+    ifs[our_iface.name]["addresses"] ||= Array.new
+    ifs[our_iface.name]["type"] = "vlan"
+    ifs[our_iface.name]["vlan"] = our_iface.vlan
+    ifs[our_iface.name]["parent"] = our_iface.parents[0].name
+    net_ifs << our_iface.name
+  end
+  # Ditto for a bridge.
+  if network["add_bridge"]
+    bridge = if our_iface.kind_of?(Nic::Vlan)
+               "br#{our_iface.vlan}"
+             else
+               "br-#{name}"
+             end
+    br = if Nic.exists?(bridge)
+           Chef::Log.info("Using bridge #{bridge} for network #{name}")
+           Nic.new bridge
+         else
+           Chef::Log.info("Creating bridge #{bridge} for network #{name}")
+           Nic::Bridge.create(bridge)
+         end
+    ifs[br.name] ||= Hash.new
+    ifs[br.name]["addresses"] ||= Array.new
+    ifs[our_iface.name]["slave"] = true
+    ifs[our_iface.name]["master"] = br.name
+    br.add_slave our_iface
+    ifs[br.name]["slaves"] = [our_iface.name]
+    ifs[br.name]["type"] = "bridge"
+    our_iface = br
+    net_ifs << our_iface.name
+  end
+  # Make sure our addresses are correct
+  if_mapping[name] = net_ifs
+  ifs[our_iface.name]["addresses"] ||= Array.new
+  if addr
+    ifs[our_iface.name]["addresses"] << addr
+    addr_mapping[name] ||= Array.new
+    addr_mapping[name] << addr.to_s
+    # Ditto for our default route
+    if network["router_pref"] && (network["router_pref"].to_i < route_pref)
+      Chef::Log.info("#{name}: Will use #{network["router"]} as our default route")
+      route_pref = network["router_pref"].to_i
+      default_route = {:nic => our_iface.name, :gateway => network["router"]}
     end
   end
 end
 
+# Kill any nics that we don't want hanging around anymore.
+old_ifs.each do |name,params|
+  next if ifs[name]
+  Chef::Log.info("#{name} is no longer being used, deconfiguring it.")
+  Nic.new(name).destroy if Nic.exists?(name)
+  case node["platform"]
+  when "centos","redhat"
+    # Redhat and Centos have lots of small files definining interfaces.
+    # Delete the ones we no longer care about here.
+    if ::File.exists?("/etc/sysconfig/network-scripts/ifcfg-#{name}")
+      ::File.delete("/etc/sysconfig/network-scripts/ifcfg-#{name}")
+    end
+  when "suse"
+    # SuSE also has lots of small files, but in slightly different locations.
+    if ::File.exists?("/etc/sysconfig/network/ifcfg-#{name}")
+      ::File.delete("/etc/sysconfig/network/ifcfg-#{name}")
+    end
+    if ::File.exists?("/etc/sysconfig/network/ifroute-#{name}")
+      ::File.delete("/etc/sysconfig/network/ifroute-#{name}")
+    end
+  end
+end
 
-def deorder(i)
-  i.reject{|k,v|
-    [:order,:associated_network].member?(k) or
-    v.nil? or
-    (v.respond_to?(:empty?) and v.empty?)
+Nic.refresh_all
+
+# At this point, any new interfaces we need have been configured, we know
+# what IP addresses should be assigned to each interface, and we know what
+# default route we should use. Make reality match our expectations.
+Nic.nics.each do |nic|
+  # If this nic is neither in our old config nor in our new config, skip
+  next unless ifs[nic.name]
+  iface = ifs[nic.name]
+  old_iface = old_ifs[nic.name]
+  # If we are a member of a bond or a bridge, then the bond or bridge
+  # gets our config instead of us. The order in which Nic.nics returns
+  # interfaces ensures that this will always function properly.
+  if (master = nic.bond_master || nic.bridge_master)
+    if iface["slave"]
+      # We should continue to be a slave.
+      Chef::Log.info("#{master.name}: usurping #{nic.name}")
+      ifs[nic.name]["addresses"].each{|a|
+        ifs[master.name]["addresses"] << a
+      }
+      ifs[nic.name]["addresses"] = []
+      default_route[:nic] = master.name if default_route[:nic] == nic.name
+      if_mapping.each { |k,v|
+        v << master.name if v.last == nic.name
+      }
+    else
+      # We no longer want to be a slave.
+      Chef::Log.info("#{nic.name} no longer wants to be a slave of #{master.name}")
+      master.remove_slave nic
+    end
+  end
+  nic.up
+  Chef::Log.info("#{nic.name}: current addresses: #{nic.addresses.map{|a|a.to_s}.sort.inspect}") unless nic.addresses.empty?
+  Chef::Log.info("#{nic.name}: required addresses: #{iface["addresses"].map{|a|a.to_s}.sort.inspect}") unless iface["addresses"].empty?
+  # Ditch old addresses, add new ones.
+  old_iface["addresses"].reject{|i|iface["addresses"].member?(i)}.each do |addr|
+    Chef::Log.info("#{nic.name}: Removing #{addr.to_s}")
+    nic.remove_address addr
+  end if old_iface
+  iface["addresses"].reject{|i|nic.addresses.member?(i)}.each do |addr|
+    Chef::Log.info("#{nic.name}: Adding #{addr.to_s}")
+    nic.add_address addr
+  end
+  # Make sure we are using the proper default route.
+  if ::Kernel.system("ip route show dev #{nic.name} |grep -q default") &&
+      (default_route[:nic] != nic.name)
+    Chef::Log.info("Removing default route from #{nic.name}")
+    ::Kernel.system("ip route del default dev #{nic.name}")
+  elsif default_route[:nic] == nic.name
+    ifs[nic.name]["gateway"] = default_route[:gateway]
+    unless ::Kernel.system("ip route show dev #{nic.name} |grep -q default")
+      Chef::Log.info("Adding default route via #{default_route[:gateway]} to #{nic.name}")
+      ::Kernel.system("ip route add default via #{default_route[:gateway]} dev #{nic.name}")
+    end
+  end
+end
+
+if ["delete","reset"].member?(node["state"])
+  # We just had the rug pulled out from under us.
+  # Do our darndest to get an IP address we can use.
+  Nic.refresh_all
+  Nic.nics.each{|n|
+    next if n.name =~ /^lo/
+    n.up
+    break if ::Kernel.system("dhclient -1 #{n.name}")
   }
 end
 
-def only_router_changed(a,b)
-  deorder(a.reject{|k,v| k == :router}) == deorder(b.reject{|k,v| k == :router})
-end
+# Wait for the administrative network to come back up.
+Chef::Log.info("Waiting up to 60 seconds for the net to come back")
+60.times do
+  break if ::Kernel.system("ping -c 1 -w 1 -q #{provisioner.address.addr}")
+  sleep 1
+end if provisioner
 
-Chef::Log.info("Current interfaces:\n#{old_interfaces.inspect}\n")
-Chef::Log.info("New interfaces:\n#{new_interfaces.inspect}\n")
+node.set["crowbar_wall"] ||= Mash.new
+node.set["crowbar_wall"]["network"] ||= Mash.new
+saved_ifs = Mash.new
+ifs.each {|k,v|
+  addrs = v["addresses"].map{|a|a.to_s}.sort
+  saved_ifs[k]=v
+  saved_ifs[k]["addresses"] = addrs
+}
+Chef::Log.info("Saving interfaces to crowbar_wall: #{saved_ifs.inspect}")
 
-if (not new_interfaces) or new_interfaces.empty?
-  Chef::Log.fatal("Crowbar instructed us to tear down all our interfaces!")
-  Chef::Log.fatal("Refusing to do so.")
-  raise ::RangeError.new("Not enough active network interfaces.")
-end
+node.set["crowbar_wall"]["network"]["interfaces"] = saved_ifs
+node.set["crowbar_wall"]["network"]["nets"] = if_mapping
+node.set["crowbar_wall"]["network"]["addrs"] = addr_mapping
+node.save
 
-
-# rewrite the network configuration to match the new config.
-# do this while we have stable connectivity to the server.
-case node[:platform]
-when "ubuntu","debian"
+case node["platform"]
+when "debian","ubuntu"
   template "/etc/network/interfaces" do
     source "interfaces.erb"
-    variables :interfaces => new_interfaces.values.sort{|a,b| 
-      a[:order] <=> b[:order]
-    }
+    owner "root"
+    group "root"
+    variables({ :interfaces => ifs })
   end
 when "centos","redhat"
-  new_interfaces.values.each do |iface|
-    template "/etc/sysconfig/network-scripts/ifcfg-#{iface[:interface]}" do
+  # add redhat-specific code here
+  Nic.nics.each do |nic|
+    next unless ifs[nic.name]
+    template "/etc/sysconfig/network-scripts/ifcfg-#{nic.name}" do
       source "redhat-cfg.erb"
-      variables :iface => iface
+      owner "root"
+      group "root"
+      variables({
+                  :interfaces => ifs, # the array of config values
+                  :nic => nic # the live object representing the current nic.
+                })
     end
   end
-end
-
-# First, tear down any interfaces that are going to be deleted in 
-# reverse order in which they appear in the current /etc/network/interfaces
-(old_interfaces.keys - new_interfaces.keys).sort {|a,b| 
-  old_interfaces[b][:order] <=> old_interfaces[a][:order]}.each do |i|
-  next if i.nil? or i == ""
-  Chef::Log.info("Removing #{old_interfaces[i]}\n")
-  bash "ifdown #{i} for removal" do
-    code "ifdown #{i}"
-    ignore_failure true
-  end
-  case node[:platform]
-  when "ubuntu","debian"
-    # No-op
-  when "centos","redhat"
-    file "/etc/sysconfig/network-scripts/ifcfg-#{i}" do
-      action :delete
+when "suse"
+  Nic.nics.each do |nic|
+    next unless ifs[nic.name]
+    template "/etc/sysconfig/network/ifcfg-#{nic.name}" do
+      source "suse-cfg.erb"
+      variables({
+                  :interfaces => ifs,
+                  :nic => nic
+                })
     end
+    template "/etc/sysconfig/network/ifroute-#{nic.name}" do
+      source "suse-route.erb"
+      variables({
+                  :interfaces => ifs,
+                  :nic => nic
+                })
+    end if ifs[nic.name]["gateway"]
   end
 end
-
-# Second, examine each interface that exists in both the old and the
-# new configuration to see what changed, and take appropriate action.
-(old_interfaces.keys & new_interfaces.keys).sort {|a,b|
-  new_interfaces[a][:order] <=> new_interfaces[b][:order]}.each do |i|
-  case
-  when deorder(old_interfaces[i]) == deorder(new_interfaces[i])
-    # The only thing that changed is the proposed position in the interfaces
-    # file.  Don't do anything with this interface.
-    Chef::Log.info("#{i} did not change, skipping.")
-  when only_router_changed(old_interfaces[i], new_interfaces[i])
-    Chef::Log.info("Default route through #{i} changed, handling specially.")
-    if old_interfaces[i][:router]
-      bash "Remove default route through #{i}" do
-        code "ip route del default via #{old_interfaces[i][:router]} dev #{i}"
-        only_if "ip route show dev #{i} |grep -q default"
-      end
-    end
-    if new_interfaces[i][:router]
-      bash "Add default route through #{i}" do
-        code "ip route add default via #{new_interfaces[i][:router]} dev #{i}"
-        not_if "ip route show dev #{i} |grep -q default"
-      end
-    end
-  when old_interfaces[i][:config] == "dhcp"
-    Chef::Log.info("Taking ownership of #{i}")
-    # We are going to transition an interface into being owned by Crowbar.
-    # Kill any dhclients for this interface, and then take action
-    # based on whether we are giving it an IP address or not.
-    bash "kill dhclients" do
-      code "killall dhclient3 ; rm -rf /etc/dhclient*"
-      only_if "pidof dhclient3"
-    end
-    if new_interfaces[i][:config] == "static"
-      # We are giving it a static IP.  Schedule the interface to be 
-      # forced up with the new config, which should give it the new 
-      # configuration without taking the link down.
-      # We rely on our static network config being otherwise identical
-      # to our DHCP config.
-      interfaces_to_up[i] = "ifup #{i}"
-    else
-      # We are giving it a manual config. We don't want to take the link down,
-      # so just flush its addresses and routes, and hope that is enough.
-      interfaces_to_up[i] = "ip addr flush dev #{i}; ip route flush dev #{i}; ip link set #{i} up"
-    end
-  else
-    Chef::Log.info("Transitioning #{i}:\n#{old_interfaces[i].inspect}\n=>\n#{new_interfaces[i].inspect}\n")
-    # The interface changed, and it is not a matter of taking ownership
-    # from the OS.  ifdown it now, and schedule it to be ifup'ed if 
-    # the new config is set to :auto.
-    bash "ifdown #{i} for reconfigure" do
-      code "ifdown #{i}"
-      ignore_failure true
-    end
-    interfaces_to_up[i] = "ifup #{i}" if new_interfaces[i][:auto]
-  end
-end
-
-# Third, bring up any new or changed interfaces
-new_interfaces.values.sort{|a,b|a[:order] <=> b[:order]}.each do |i|
-  next if i[:interface] == "bmc"
-  case
-  when (old_interfaces[i[:interface]].nil? and i[:auto])
-    # This is a new interface.  Ifup it if it should be auto ifuped.
-    bash "ifup new #{i[:interface]}" do
-      code "ifup #{i[:interface]}"
-      ignore_failure true
-    end
-  when interfaces_to_up[i[:interface]]
-    # This is an interface that we had in common with old_interfaces that
-    # did not have an identical configuration from the last time.
-    # We need to bring it up according to the instructions left behind.
-    bash "ifup reconfigured #{i[:interface]}" do
-      code interfaces_to_up[i[:interface]]
-      ignore_failure true
-    end
-  else
-    next
-  end
-  # Only delay if we ifup'ed a real physical interface.
-  delay = ::File.exists? "/sys/class/net/#{i[:interface]}/device" unless delay
-end
-
-# If we need to sleep now, do it.
-delay_time = delay ? node["network"]["start_up_delay"] : 0
-Chef::Log.info "Will sleep for #{delay_time} seconds due new link coming up"
-bash "network delay sleep" do
-  code "sleep #{delay_time}"
-  only_if { delay_time > 0 }
-end
-

--- a/chef/cookbooks/network/recipes/switch_config.rb
+++ b/chef/cookbooks/network/recipes/switch_config.rb
@@ -47,7 +47,7 @@ def setup_interface(switch_config, a_node, conduit, switch_name, interface_id )
     end
 end
 
-admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+admin_ip = node.address.addr
 
 switch_config={}
 

--- a/chef/cookbooks/network/templates/default/interfaces.erb
+++ b/chef/cookbooks/network/templates/default/interfaces.erb
@@ -1,42 +1,54 @@
 # Managed by Crowbar via Chef.
-# Do not manually edit, all your changes will be reverted and your 
-# networking will be undone.  
+# Do not manually edit, all your changes will be reverted and your
+# networking will be undone.
 auto lo
 iface lo inet loopback
 
-<% @interfaces.each do |interface| -%>
-<% next if interface[:interface] == "bmc" -%>
-<% if interface[:auto] -%>
-auto <%= interface[:interface] %>
+<% ::Nic.nics.each do |nic|
+  next unless @interfaces[nic.name]
+  name = nic.name
+  i = @interfaces[name]
+  addrs = i["addresses"].dup.map{|a|::IP.coerce(a)}
+  addr = addrs.shift
+  -%>
+auto <%= name %>
+<% if addr.kind_of?(IP::IP4) -%>
+iface <%= name %> inet static
+<% elsif addr.kind_of?(IP::IP6) -%>
+iface <%= name %> inet6 static
+<% else -%>
+iface <%= name %> inet manual
 <% end -%>
-iface <%= interface[:interface] %> inet <%= interface[:config] %>
-<% if !interface[:ipaddress].nil? -%>
-  address <%= interface[:ipaddress] %>
+<% unless addr.nil? -%>
+    address <%= addr.to_s.split('/')[0] %>
+    netmask <%= addr.to_s.split('/')[1] %>
 <% end -%>
-<% if !interface[:netmask].nil? -%>
-  netmask <%= interface[:netmask] %>
+<% addrs.each do |a| -%>
+    post-up ip addr add <%= a %> dev <%= name %> || true
+    pre-down ip addr del <%= a %> dev <%= name %> || true
 <% end -%>
-<% if !interface[:broadcast].nil? -%>
-  broadcast <%= interface[:broadcast] %>
+<% if i["gateway"] -%>
+    post-up ip route add default via <%= i["gateway"] %> dev <%= name %> || true
+    pre-down ip route del default via <%= i["gateway"] %> dev <%= name %> || true
 <% end -%>
-<% if !interface[:mtu].nil? -%>
-  mtu <%= interface[:mtu] %>
-<% end -%>
-<% if !interface[:router].nil? -%>
-  gateway <%= interface[:router] %>
-<% end -%>
-<% case interface[:mode] -%>
-<% when "bridge" -%>
-  bridge_ports <%= interface[:interface_list].join %>
-  bridge_stp on
-  bridge_maxwait 0
-  bridge_fd 0
-<% when "vlan" -%>
-  vlan_raw_device <%= interface[:interface_list].first %>
-<% when "team" -%>
-  down /sbin/ifenslave -d <%= interface[:interface] %> <%= interface[:interface_list].join(" ") %>
-  up /sbin/ifenslave <%= interface[:interface] %> <%= interface[:interface_list].join(" ") %>
-<% end -%>
-
+<% case
+       when i["type"] == "bridge"-%>
+    bridge_ports <%= i["slaves"].join %>
+    bridge_stp on
+    bridge_maxwait 0
+    bridge_fd 0
+<% when i["type"] == "vlan" -%>
+    vlan_raw_device <%= i["parent"] %>
+<% when i["type"] == "bond" -%>
+    pre-up test -f /sys/class/net/bonding_masters || modprobe bonding
+    pre-up grep -qw <%=name%> /sys/class/net/bonding_masters || echo +<%=name%> >/sys/class/net/bonding_masters || true
+    pre-up echo <%=i["mode"] %> >/sys/class/net/<%=name%>/bonding/mode || true
+       <% i["slaves"].each do |slave| -%>
+    up ip link set <%=slave%> down
+    up echo +<%=slave%> > /sys/class/net/<%=name%>/bonding/slaves || true
+    down echo -<%=slave%> > /sys/class/net/<%=name%>/bonding/slaves || true
+       <% end # interface.slaves.each -%>
+    post-down echo -<%=name%> >/sys/class/net/bonding_masters || true
+    <% end # case -%>
 <% end # loop -%>
 

--- a/chef/cookbooks/network/templates/default/redhat-cfg.erb
+++ b/chef/cookbooks/network/templates/default/redhat-cfg.erb
@@ -1,41 +1,38 @@
 # Managed by Crowbar.
 # Do not edit.
-<% @iface.keys.each do |k|
-    v=@iface[k]
-    next unless v
-    next if v.class == Array and v.empty?
-    case k
-    when :interface then k="DEVICE"
-    when :auto then
-    	 if v == true
-       	    k="ONBOOT"
-       	    v="yes"
-	 end
-    when :config
-      	 k="BOOTPROTO"
-      	 case v
-      	 when "static","manual"
-              v = "none"
-      	 end
-    when :ipaddress then k="IPADDR"
-    when :netmask then k="NETMASK"
-    when :bond_opts then k="BONDING_OPTS"
-    when :broadcast then k="BROADCAST"
-    when :mtu then k="MTU"; v=iface[k].to_s
-    when :router then k="GATEWAY"
-    when :master then k="MASTER"
-    when :slave
-      if v == true
-        k="SLAVE"
-        v="yes"
-      end
-    when :bridge
-      k="BRIDGE"
-    when :vlan
-      k="VLAN"
-      v="yes"
-    end
-    next if k.class != String 
-    quote = ((v.include? " ") ? "\"" : "") -%>
-<%= "#{k}=#{quote}#{v}#{quote}" %>
+<% iface = @interfaces[@nic.name] -%>
+DEVICE=<%=@nic.name%>
+<% case
+   when @nic.kind_of?(Nic::Bridge) -%>
+TYPE=Bridge
+<% if @nic.stp -%>
+STP=yes
+DELAY=<%=@nic.forward_delay%>
+<% else -%>
+STP=no
+<% end -%>
+<% when @nic.kind_of?(Nic::Bond) -%>
+BONDING_OPTS="miimon=<%=@nic.miimon%> mode=<%=@nic.mode%>"
+<% when @nic.kind_of?(Nic::Vlan) -%>
+VLAN=yes
+<% when @nic.kind_of?(Nic) -%>
+#HWADDR=<%=@nic.mac%>
+TYPE=Ethernet
+<% end -%>
+<% if @nic.bond_master -%>
+SLAVE=yes
+MASTER=<%=@nic.bond_master.name%>
+<% end -%>
+<% if @nic.bridge_master-%>
+BRIDGE=<%=@nic.bridge_master.name%>
+<% end -%>
+ONBOOT=yes
+BOOTPROTO=none
+<% v4addrs, v6addrs = iface["addresses"].map{|a|::IP.coerce(a)}.partition{|a|a.kind_of? IP::IP4}
+   v4addrs.each_index do |i| -%>
+IPADDR<%=(i == 0)?'':(i+1).to_s%>=<%=v4addrs[i].to_s.split('/')[0]%>
+PREFIX<%=(i == 0)?'':(i+1).to_s%>=<%=v4addrs[i].subnet%>
+<% end -%>
+<% if iface["gateway"] -%>
+GATEWAY=<%=iface["gateway"]%>
 <% end -%>

--- a/chef/cookbooks/network/templates/default/suse-cfg.erb
+++ b/chef/cookbooks/network/templates/default/suse-cfg.erb
@@ -1,0 +1,40 @@
+# Managed by Crowbar.
+# Do not edit.
+<%
+# quote a string for the shell
+# usage: "VARIABLE=#{quote value}"
+def quote(s)
+  # Watch out, in gsub \' means "after the matched string"
+  # We must escape it once to get rid of that
+  # and the second time in double quotes
+  # so that "Joe's" comes out as WHOSE='Joe'\''s'
+  # Using to_s for nils and numbers.
+  "'" + s.to_s.gsub(/'/, "'\\\\''") + "'"
+end
+iface=@interfaces[@nic.name]
+-%>
+NAME=<%=quote(@nic.name)%>
+STARTMODE=auto
+<% if iface["slave"] -%>
+BOOTPROTO=none
+<% else -%>
+BOOTPROTO=static
+<% end -%>
+<% case
+   when @nic.kind_of?(Nic::Bridge) -%>
+BRIDGE=yes
+BRIDGE_PORTS=<%=quote(iface["slaves"])%>
+<% when @nic.kind_of?(Nic::Vlan) -%>
+VLAN_ID=<%=iface["vlan"]%>
+ETHERDEVICE=<%=quote(iface["parent"])%>
+<% when @nic.kind_of?(Nic::Bond) -%>
+BONDING_MASTER=yes
+BONDING_MODULE_OPTS=<%=quote("mode=#{@nic.mode} miimon=#{@nic.miimon}")%>
+<% iface["slaves"].each_with_index do |slave,i| -%>
+BONDING_SLAVE_<%=i%>=<%=quote(slave)%>
+<% end -%>
+<% end -%>
+<% v4addrs, v6addrs = iface["addresses"].map{|a|::IP.coerce(a)}.partition{|a|a.kind_of? IP::IP4}
+   v4addrs.each_index do |i| -%>
+IPADDR<%=(i == 0)?'':(i+1).to_s%>=<%=v4addrs[i].to_s%>
+<% end -%>

--- a/chef/cookbooks/network/templates/default/suse-route.erb
+++ b/chef/cookbooks/network/templates/default/suse-route.erb
@@ -1,0 +1,3 @@
+# Managed by Crowbar.
+# Do not edit.
+<%= "default #{@interfaces[@nic.name]["gateway"]}" %>


### PR DESCRIPTION
This backports the network barclamp recipies from Crowbar 2.0 into Pebbles.

From the original commit:

Rewrite network barclamp to manage interfaces directly.

```
Making the distro tools handle reconfiguring network interfaces for us
was needlessly fragile, since we were rewriting the network config and
changing the state of the interfaces while we were in the middle of
converging the node -- if we happened to do anything that would try to
talk to the chef-server while any of the interfaces needed to talk to
the admin network was changing, we could easily wind up in a state
where manual intervention would be needed to recover.

Additionally, the network barclamp had to have a good deal of
special-casing to handle all the distro-specific caveats that went
along with using ifup/ifdown directly to manage the nics.

This code does away with all that by teaching the network barclamp how
to manage our interfaces directly, reducing the distro-specific code
to what is needed to write out the proper configuation for ifup/ifdown
on the operating system.

New features:

 * All interface manipulation happens early in the compile phase of
   the chef-client runs, and the recipe will pause for up to 60
   seconds to verify that it can ping the node with the provisioner
   role (if one is assigned).  This should ensure that the chef-client
   run succeeds with minimal delay even when we are forced to do
   something that may trigger a spanning tree update on the
   network. This frees the rest of the barclamps from having to care
   about sleeping due to network configuration changes.
 * The network barclamp posts its state on
   node[:crowbar_wall][:network] to allow other barclamps to easily
   see what interfaces are members of what network and what IP
   addresses are assigned to the node.
 * Switching between single, dual, and team mode is more or less
   seamless now. You can easily switch network modes even when nova VMs are
   up and running without dropping more than a packet or two. The sole
   exception I have seen is Nova running in tenant_vlan mode.
 * It is trivial to deploy with a configuration that does not use vlan
   tagging at all.  The network barclamp will manage our interfaces
   correctly by assigning multiple IP addresses to the appropriate
   interfaces for each network, and it will handle moving addresses
   and routes around as needed.  Debian and Redhat config file
   generation has been updated to handle binding multiple IP addresses
   to interfaces so that a rebooted node will come up with the proper
   configuration before chef-client runs.
 * Helper classes have been added to the barclamp recipe that model IP
   addresses (including IP address ranges) and network interfaces.
   Those helpers also inject convienenece routines into the CHef::Node
   class to make it easier to find interfaces and addresses for each
   of our networks.
```

 chef/cookbooks/network/metadata.rb                 |    6 +
 chef/cookbooks/network/recipes/default.rb          |  784 ++++++++------------
 chef/cookbooks/network/recipes/switch_config.rb    |    2 +-
 .../network/templates/default/interfaces.erb       |   76 +-
 .../network/templates/default/redhat-cfg.erb       |   73 +-
 .../network/templates/default/suse-cfg.erb         |   40 +
 .../network/templates/default/suse-route.erb       |    3 +
 7 files changed, 425 insertions(+), 559 deletions(-)

Crowbar-Pull-ID: 57b4821d276e5da97e9a031ecb6ab6c94f74ce80

Crowbar-Release: pebbles
