### PR TITLE
Add a little more paranoia to how we create slave interfaces on demand. [2/2]

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -130,7 +130,7 @@ node["crowbar"]["network"].keys.sort{|a,b|
   # interface and/or bond that we already have
   if network["use_vlan"]
     vlan = "#{our_iface.name}.#{network["vlan"]}"
-    if Nic.exists?(vlan)
+    if Nic.exists?(vlan) && Nic.vlan?(vlan)
       Chef::Log.info("Using vlan #{vlan} for network #{name}")
       our_iface = Nic.new vlan
     else
@@ -159,7 +159,7 @@ node["crowbar"]["network"].keys.sort{|a,b|
              else
                "br-#{name}"
              end
-    br = if Nic.exists?(bridge)
+    br = if Nic.exists?(bridge) && Nic.bridge?(bridge)
            Chef::Log.info("Using bridge #{bridge} for network #{name}")
            Nic.new bridge
          else


### PR DESCRIPTION
Make sure that the Nic class waits for any freshly-created nics to
show up before returning the proxy objects, and modify the network
recipe to be a little more paranoid about what it accepts from the Nic
helper classes.

 chef/cookbooks/network/recipes/default.rb |    4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: a4d8ab56ca829d93bd8b8eae3227afb156b139db

Crowbar-Release: pebbles
