### PR TITLE
Make the network recipe die informativly if conduit mapping is insane. [2/2]

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -105,11 +105,7 @@ node["crowbar"]["network"].keys.sort{|a,b|
       (network["teaming"] && network["teaming"]["mode"]) || 5
     # See if a bond that matches our specifications has already been created,
     # or if there is an empty bond lying around.
-    bond = Nic.nics.detect do |i|
-      i.kind_of?(Nic::Bond) &&
-        (i.slaves.empty? ||
-         (i.slaves.sort == base_ifs))
-    end
+    bond = Nic::Bond.find(base_ifs)
     if bond
       Chef::Log.info("Using bond #{bond.name} for network #{name}")
     else


### PR DESCRIPTION
If the network barclamp was handed an obviously insane conduit mapping
(one that contains either nils or references to interfaces that do not
exist), die with an informative error message instead of a more opaque one.

 chef/cookbooks/network/recipes/default.rb |    9 +++++++--
 1 file changed, 7 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 4e6cc193a8cbbe598d32acfed9e47d422573a504

Crowbar-Release: pebbles
