### PR TITLE
Do not create a bridge device for nova_fixed anymore

### DIFF
--- a/chef/data_bags/crowbar/bc-template-network.json
+++ b/chef/data_bags/crowbar/bc-template-network.json
@@ -162,7 +162,7 @@
           "conduit": "intf1",
           "vlan": 500,
           "use_vlan": true,
-          "add_bridge": true,
+          "add_bridge": false,
           "subnet": "192.168.123.0",
           "netmask": "255.255.255.0",
           "broadcast": "192.168.123.255",


### PR DESCRIPTION
nova-network support got removed and the nova_fixed network is now only used by
quantum. In ovs mode the ovs bridges will be created by the quantum cookbook.
In linuxbridge mode the linuxbridge agent will manage it. If crowbar already
created the bridge this would not work.
