### PR TITLE
Use bonding mode 5 (balance-tlb) by default

### DIFF
--- a/chef/data_bags/crowbar/bc-template-network.json
+++ b/chef/data_bags/crowbar/bc-template-network.json
@@ -6,7 +6,7 @@
       "start_up_delay": 30,
       "mode": "single",
       "teaming": {
-        "mode": 6
+        "mode": 5
       },
       "interface_map": [
         {
@@ -60,16 +60,13 @@
           "pattern": "team/.*/.*",
           "conduit_list": { 
             "intf0": {
-              "if_list": [ "1g1", "1g2" ],
-              "team_mode": 6
+              "if_list": [ "1g1", "1g2" ]
             },
             "intf1": {
-              "if_list": [ "1g1", "1g2" ],
-              "team_mode": 6
+              "if_list": [ "1g1", "1g2" ]
             },
             "intf2": {
-              "if_list": [ "1g1", "1g2" ],
-              "team_mode": 6
+              "if_list": [ "1g1", "1g2" ]
             }
           }
         },


### PR DESCRIPTION
The old default (mode 6, balance-alb) does not work reliably when the
bond device is attached to a bridge. See e.g.:
https://bugzilla.redhat.com/show_bug.cgi?id=560588#c14

Some of those issue have been fixed in very recent kernels (3.8 and later), but
we should not rely on that. (SLES 11 is that 3.0.x, Ubuntu 12.04 is 3.2.x or
3.5.x)

This patch also removes the redundant "team_mode" settings from the
conduit_list for the team mode. The network barclamp will default to what's
configured in the global "mode" setting in that case.
