### PR TITLE
Send ping output to /dev/null

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -309,7 +309,7 @@ end
 # Wait for the administrative network to come back up.
 Chef::Log.info("Waiting up to 60 seconds for the net to come back")
 60.times do
-  break if ::Kernel.system("ping -c 1 -w 1 -q #{provisioner.address.addr}")
+  break if ::Kernel.system("ping -c 1 -w 1 -q #{provisioner.address.addr} > /dev/null")
   sleep 1
 end if provisioner
 


### PR DESCRIPTION
Using -q is not enough to make ping silent: it will still output the
ping summary. So let's make it really quiet by redirecting stdout to
/dev/null.
