### PR TITLE
Allow using the serial number of a node as an additional matching criteria for the bus_order [3/3]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-network.schema
+++ b/chef/data_bags/crowbar/bc-template-network.schema
@@ -29,6 +29,7 @@
                 "required": true,
                 "mapping": {
                   "pattern": { "type": "str", "required": true },
+                  "serial_number": { "type": "str", "required": false },
                   "bus_order": {
                     "type": "seq",
                     "required": true,


### PR DESCRIPTION
This introduces a new optional attribute "serial_number" in the interface_maps
of the network barclamp (+ the needed change to make use of that in the crowbar
and deployer barclamps) that can be use as additional matching criteria for
defining the interface order for a certain node. (This is helpful e.g. if two
nodes with the same value for "Product Name" need to have different
interface_map defined)

 chef/data_bags/crowbar/bc-template-network.schema | 1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: ead8713cdc2ce28d97bab36901b28238e32bb08e

Crowbar-Release: pebbles
