### PR TITLE
Create network-related data bags from proposal, not from template

### DIFF
--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -198,20 +198,29 @@ class NetworkService < ServiceObject
     @logger.debug("Network create_proposal: entering")
     base = super
 
-    base["attributes"]["network"]["networks"].each do |k,net|
-      @logger.debug("Network: creating #{k} in the network")
-      bc = Chef::DataBagItem.new
-      bc.data_bag "crowbar"
-      bc["id"] = "#{k}_network"
-      bc["network"] = net
-      bc["allocated"] = {}
-      bc["allocated_by_name"] = {}
-      db = ProposalObject.new bc
-      db.save
-    end
-
     @logger.debug("Network create_proposal: exiting")
     base
+  end
+
+  def apply_role_pre_chef_call(old_role, role, all_nodes)
+    @logger.debug("Network apply_role_pre_chef_call: entering #{all_nodes.inspect}")
+
+    role.default_attributes["network"]["networks"].each do |k,net|
+      db = ProposalObject.find_data_bag_item "crowbar/#{k}_network"
+      if db.nil? || db.empty?
+        @logger.debug("Network: creating #{k} in the network")
+        bc = Chef::DataBagItem.new
+        bc.data_bag "crowbar"
+        bc["id"] = "#{k}_network"
+        bc["network"] = net
+        bc["allocated"] = {}
+        bc["allocated_by_name"] = {}
+        db = ProposalObject.new bc
+        db.save
+      end
+    end
+
+    @logger.debug("Network apply_role_pre_chef_call: leaving")
   end
 
   def transition(inst, name, state)


### PR DESCRIPTION
We were creating the crowbar/admin_network and friends data bags in
create_proposal, which means that the network definitions came from the
template. Which is simply wrong since we want the network definitions
from the proposal.

Instead, create the data bags from apply_role_pre_chef_call (only if the
data bags don't exist yet, to avoid issues when re-applying the
proposal).
