### PR TITLE
Do not fail if we have vlan interface with unexpected naming

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -147,7 +147,7 @@ node["crowbar"]["network"].keys.sort{|a,b|
       next unless n.kind_of?(Nic::Vlan)
       next if have_vlan_iface && n == our_iface
       next unless n.vlan == network["vlan"].to_i
-      n.destroy
+      kill_nic(n.name)
     end
     unless have_vlan_iface
       Chef::Log.info("Creating vlan #{vlan} for network #{name}")


### PR DESCRIPTION
When trying to create eth0.248, if the interface already exists but as
vlan248, we simply fail. It turns out there's code already that is
supposed to deal with that and remove vlan248, but it's executed too
late.
