### PR TITLE
Only kill vlan interfaces if they are on the same parent interface

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -146,6 +146,7 @@ node["crowbar"]["network"].keys.sort{|a,b|
     Nic.nics.each do |n|
       next unless n.kind_of?(Nic::Vlan)
       next if have_vlan_iface && n == our_iface
+      next unless n.parent == our_iface.name
       next unless n.vlan == network["vlan"].to_i
       kill_nic(n.name)
     end


### PR DESCRIPTION
When we are about to create a vlan interface, we check that there's no
interface with the same vlan id, and if there is, we kill it.

However, we were not restricting this to the vlan interface on the same
parent interface. This might lead to situations where we want to use the
same vlan id on two interfaces, but crowbar doesn't allow this.
