### PR TITLE
Fix the creation of the node.crowbar.bond_list attribute

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -128,6 +128,8 @@ node["crowbar"]["network"].keys.sort{|a,b|
     ifs[bond.name]["mode"] = team_mode
     ifs[bond.name]["type"] = "bond"
     our_iface = bond
+    node.set["crowbar"]["bond_list"] = {} if node["crowbar"]["bond_list"].nil?
+    node.set["crowbar"]["bond_list"][bond.name] = ifs[bond.name]["slaves"]
   end
   net_ifs << our_iface.name
   # If we want a vlan interface, create one on top of the base physical


### PR DESCRIPTION
Previously the node.crowbar.bond_list was maintained in barclamp_library.rb
(lookup_interface_info method) in a broken way. The names of the bond devices
it created where not aligned with the actual interfaces names on the system.

The first caller of lookup_interface_info would always get bond0, the next call
(with a differnt conduit) would get bond1, and so on.

The network cookbook however assigns the names in the order in which they are
returned from the node's crowbar.networks attribute (+ some sorting to make
sure that vlan and bridge interfaces are handled later).

This lead to broken installations of the admin node when a bastion network
is enabled, because Barclamp::Inventory.lookup_interface_info and the network
cookbook disagree about the device names.

To fix this this commit moves the maintenance of the bond_list attribute into
the network recipe and Barclamp::Inventory.lookup_interface_info will just use
what's in there.

https://bugzilla.novell.com/show_bug.cgi?id=833133
