### PR TITLE
Enhance Nic.master for ovs virtual switches [2/2]

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -253,7 +253,7 @@ Nic.nics.each do |nic|
   # If we are a member of a bond or a bridge, then the bond or bridge
   # gets our config instead of us. The order in which Nic.nics returns
   # interfaces ensures that this will always function properly.
-  if (master = nic.bond_master || nic.bridge_master)
+  if (master = nic.master)
     if iface["slave"]
       # We should continue to be a slave.
       Chef::Log.info("#{master.name}: usurping #{nic.name}")


### PR DESCRIPTION
Add a test to check whether an interface is part of a ovs virtual switch.
This is to stop the network barclamp from reconfiguring such interfaces,
similar to what is already does for linux-bridge and bond slaves.

 chef/cookbooks/network/recipes/default.rb | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: fe6235d7a36ecb5fb03d7dc3628236c4743f2296

Crowbar-Release: pebbles
