### PR TITLE
Reduce local_port_range to not overlap with ports used by services

### DIFF
--- a/chef/cookbooks/network/templates/default/sysctl_10gbe.conf.erb
+++ b/chef/cookbooks/network/templates/default/sysctl_10gbe.conf.erb
@@ -3,7 +3,7 @@
 
 # -- tuning -- #
 # Increase system IP port range to allow for more concurrent connections
-net.ipv4.ip_local_port_range = 1024 65000
+net.ipv4.ip_local_port_range = 10000 65000
 
 # -- 10gbe tuning from Intel ixgb driver README -- #
 


### PR DESCRIPTION
On system with 1GBit or 10GBit interface we adjusted the sysctl value
net.ipv4.ip_local_port_range (to 1024-65000) to allow more concurrent outgoing
connections. This range however overlaps with a lot of ports that openstack
services are listening on. In the worst case it might happen that some services
do not start because the port they want to listen on is already used by some
other process for an outgoing connection. This patch reduces the local port
range again to a saner level.

fixes: https://bugzilla.novell.com/show_bug.cgi?id=839573
