### PR TITLE
Merging Linux bridge support into Mesa 1.6.1 [1/3]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-network.json
+++ b/chef/data_bags/crowbar/bc-template-network.json
@@ -162,7 +162,7 @@
           "conduit": "intf1",
           "vlan": 500,
           "use_vlan": true,
-          "add_bridge": true,
+          "add_bridge": false,
           "subnet": "192.168.123.0",
           "netmask": "255.255.255.0",
           "broadcast": "192.168.123.255",


### PR DESCRIPTION
This pull request bundle merges neutron Linux bridge support into Mesa 1.6.1 from pebbles.

 chef/data_bags/crowbar/bc-template-network.json |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 2e7e34caa12af20d403f9baa19e5050351e2b7d9

Crowbar-Release: mesa-1.6.1
