### PR TITLE
Allow the provisioner to deploy nodes with Ubuntu 12.04 installed on them. [2/4]

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -128,8 +128,9 @@ end
 def resolve_conduit(net)
   known_ifs = node["crowbar"]["sorted_ifs"]
   speeds = %w{10m 100m 1g 10g}
+  conduit = node["crowbar"]["network"][net]["conduit"]
   intf_re = /^([-+?]?)(\d{1,3}[mg])(\d+)$/
-  finders = node["crowbar"]["network"][net]["conduit"].split(',').map{|f|f.strip}
+  finders = conduit.split(',').map{|f|f.strip}
   raise "#{conduit} does not want any interfaces!" if finders.nil? || finders.empty?
   finders = finders.map{|i|intf_re.match(i)}
   malformed = finders.find_all{|i|i.length != 4}


### PR DESCRIPTION
This pull request series adds the ability to deploy Ubuntu on nodes
that have completed the Sledgehammer discovery cycle.  Some important
caveats:
- This is a proof of concept implementation of the OS deployment
  process.  It is hardcoded to install Ubuntu, and no effort has been
  given to deploying other Linux distros for now.
- There are some race conditions that can lead to noderoles spuriously
  transitioning to ERROR.  Trtrying them in the UI usually resolves it
  -- my next patch series will target the jig/noderole race conditions
  that appear to be leading to the spurious errors.
- It has only been testec by PXE installing virtual machines. Real
  hardware might work if the disks have been wiped by something else.
- After binding the provisioner-os-install role to the nodes, they may
  reboot back into Sledgehammer instead of booting into the Ubuntu
  installer.  If that happens, leave them alone and they will
  eventually boot into the Ubuntu installer.  This is another
  manifestation of the jig/noderole race conditions.

With that in mind, here is what you need to do to boot other nodes
into Ubuntu:
- Perform an admin node bringup like normal.
- Boot other nodes on the admin network.  They should boot into
  Sledgehammer and have all thair noderoles bound.
- Wait for all the noderoles to go active.
- Create a new deployment, add the provisioner-os-install role to that
  deployment, then drag all the non-admin nodes onto the
  provisioner-os-install role.
- Commit the new deployment.
- Wait until the nodes give you an Ubuntu login prompt.
- Wait until all the noderoles in the system deployemnt turn green again.
  
  chef/cookbooks/network/recipes/default.rb | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: bd66348553d542ca5099c3c0ee4e662fe322da9f

Crowbar-Release: development
