### PR TITLE
Update the JSON to move OS_SDN

### DIFF
--- a/chef/data_bags/crowbar/bc-template-network.json
+++ b/chef/data_bags/crowbar/bc-template-network.json
@@ -211,7 +211,7 @@
         },
           "os_sdn": {
               "conduit": "intf1",
-              "vlan": 700,
+              "vlan": 400,
               "use_vlan": true,
               "add_bridge": false,
               "subnet": "192.168.130.0",


### PR DESCRIPTION
Moving os_sdn to vlan 400 to support Nova-Fixed

 chef/data_bags/crowbar/bc-template-network.json |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 16c51601ae190f75239dceee800255f80410d450

Crowbar-Release: mesa-1.6.1
