### PR TITLE
Merging fix to move os_sdn to vlan 400 to roxy [1/1]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-network.json
+++ b/chef/data_bags/crowbar/bc-template-network.json
@@ -208,7 +208,7 @@
         },
           "os_sdn": {
               "conduit": "intf1",
-              "vlan": 700,
+              "vlan": 400,
               "use_vlan": true,
               "add_bridge": false,
               "subnet": "192.168.130.0",


### PR DESCRIPTION
This pull request merges the fix to move the os_sdn network from vlan 700 to vlan 400 to roxy.

 chef/data_bags/crowbar/bc-template-network.json |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: ceef7ace28b656179488b25828fdab9455af0d7f

Crowbar-Release: roxy
