### PR TITLE
Merging fix for CES-1074: Default Gateway is not defined on the Nova-Controller [2/2]

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -252,6 +252,7 @@ Nic.nics.each do |nic|
   next unless ifs[nic.name]
   iface = ifs[nic.name]
   old_iface = old_ifs[nic.name]
+  enslaved = false
   # If we are a member of a bond or a bridge, then the bond or bridge
   # gets our config instead of us. The order in which Nic.nics returns
   # interfaces ensures that this will always function properly.
@@ -271,31 +272,29 @@ Nic.nics.each do |nic|
       # We have been enslaved to an interface not managed by Crowbar.
       # Skip any further configuration of this nic.
       Chef::Log.info("#{nic.name} is enslaved to #{master.name}, which was not created by Crowbar")
-      Chef::Log.info("Refusing to change #{nic} configuration.")
-      # But still update "gateway" to write the right default route to
-      # the config files, otherwise things might break after a reboot
-      if default_route[:nic] == nic.name
-        ifs[nic.name]["gateway"] = default_route[:gateway]
-      end
-      next
+      enslaved = true
     else
       # We no longer want to be a slave.
       Chef::Log.info("#{nic.name} no longer wants to be a slave of #{master.name}")
       master.remove_slave nic
     end
   end
-  nic.up
-  Chef::Log.info("#{nic.name}: current addresses: #{nic.addresses.map{|a|a.to_s}.sort.inspect}") unless nic.addresses.empty?
-  Chef::Log.info("#{nic.name}: required addresses: #{iface["addresses"].map{|a|a.to_s}.sort.inspect}") unless iface["addresses"].empty?
-  # Ditch old addresses, add new ones.
-  old_iface["addresses"].reject{|i|iface["addresses"].member?(i)}.each do |addr|
-    Chef::Log.info("#{nic.name}: Removing #{addr.to_s}")
-    nic.remove_address addr
-  end if old_iface
-  iface["addresses"].reject{|i|nic.addresses.member?(i)}.each do |addr|
-    Chef::Log.info("#{nic.name}: Adding #{addr.to_s}")
-    nic.add_address addr
+
+  if !enslaved
+    nic.up
+    Chef::Log.info("#{nic.name}: current addresses: #{nic.addresses.map{|a|a.to_s}.sort.inspect}") unless nic.addresses.empty?
+    Chef::Log.info("#{nic.name}: required addresses: #{iface["addresses"].map{|a|a.to_s}.sort.inspect}") unless iface["addresses"].empty?
+    # Ditch old addresses, add new ones.
+    old_iface["addresses"].reject{|i|iface["addresses"].member?(i)}.each do |addr|
+      Chef::Log.info("#{nic.name}: Removing #{addr.to_s}")
+      nic.remove_address addr
+    end if old_iface
+    iface["addresses"].reject{|i|nic.addresses.member?(i)}.each do |addr|
+      Chef::Log.info("#{nic.name}: Adding #{addr.to_s}")
+      nic.add_address addr
+    end
   end
+
   # Make sure we are using the proper default route.
   if ::Kernel.system("ip route show dev #{nic.name} |grep -q default") &&
       (default_route[:nic] != nic.name)


### PR DESCRIPTION
Merging fix for CES-1074: Default route is not defined on the Nova-Controller from mesa 1.6.1 into roxy.

 chef/cookbooks/network/recipes/default.rb |   35 ++++++++++++++---------------
 1 file changed, 17 insertions(+), 18 deletions(-)

Crowbar-Pull-ID: 21621ccb9cd2ab63811fbe42f4b4f6e2dbbd1d59

Crowbar-Release: roxy
