### PR TITLE
Correct BDD failure on Network [1/1]

### DIFF
--- a/BDD/features/network.feature
+++ b/BDD/features/network.feature
@@ -10,7 +10,7 @@ Feature: Networks
     When REST gets the {object:network} "admin"
     Then the {object:network} is properly formatted
       And key "v6prefix" should not be "auto"
-      And key "v6prefix" should be "null"
+      And key "v6prefix" should not be "null"
       And key "v6prefix" should match "null|([a-f0-9]){1,4}:([a-f0-9]){1,4}:([a-f0-9]){1,4}:([a-f0-9]){1,4}"
   
   Scenario: REST JSON check


### PR DESCRIPTION
This test was failing because we changed how the default admin network is generated.

The modified test reflects the correct/current approach.

 BDD/features/network.feature |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 57f681ea989524d7e1f48317408fda498c85dac2

Crowbar-Release: development
