### PR TITLE
Pull in proper packages for OpenSUSE 12.3 [2/4]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -35,20 +35,21 @@ roles:
     flags:
       - server
 rpms:
-  redhat-6.2:
+  redhat-6.4:
     pkgs:
-      - rpcbind
-  centos-6.2:
+      - vconfig
+      - iptables-ipv6
+  centos-6.4:
     pkgs:
-      - rpcbind
+      - vconfig
+      - iptables-ipv6
+  opensuse-12.3:
+    pkgs:
+      - vlan
   pkgs:
     - bridge-utils
-    - vconfig
     - dhcp
-    - tftp-server
-    - nfs-utils
     - iptables
-    - iptables-ipv6
 debs:
   ubuntu-12.04:
     pkgs:
@@ -58,6 +59,3 @@ debs:
     - vlan
     - ifenslave-2.6
     - isc-dhcp-client
-    - tftpd-hpa
-    - nfs-common
-    - nfs-kernel-server


### PR DESCRIPTION
This pull request allows the build process to pull in all the packages
opensuse 12.3 should need to allow a Crowbar admin node to bootstrap
itself.

At this point, we still cannot bring up a fully-functional CB 2.0 node
on Opensuse due to the lack of a working Chef 11 Server -- the
omniinstall version for RHEL does not work due to systemd, and I have
not tried the natively packaged version.

 crowbar.yml | 20 +++++++++-----------
 1 file changed, 9 insertions(+), 11 deletions(-)

Crowbar-Pull-ID: 6c0b42217dd2877ca92d408c68dc8c8d57bd5cd8

Crowbar-Release: development
