### PR TITLE
Node.hint allows you to request IP (and other attributes) when Node is created in API [2/3]

### DIFF
--- a/BDD/features/network_role.feature
+++ b/BDD/features/network_role.feature
@@ -1,0 +1,12 @@
+Feature: Network Role
+  In order to setup networks, the Operator 
+  wants to be able to handle network configuration activities
+
+  Scenario: Node set IP address from hint
+    Given there is a {object:node} "bdd-hint-ip2.data.edu" hinted "ip" as "192.168.124.126"
+      And parameter "node" is "bdd-hint-ip2.data.edu"
+      And there are no pending Crowbar runs for {o:node} "bdd-hint-ip2.data.edu"
+    When REST requests the "network/api/v2/networks/admin/allocations" page with parameter "node"
+    Then Array matches "192\.168\.124\.126\/([0-9]{2})" 
+    Finally there are no pending Crowbar runs for {o:node} "bdd-hint-ip2.data.edu"
+      And REST removes the {object:node} "bdd-hint-ip2.data.edu"

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/role.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/role.rb
@@ -65,7 +65,11 @@ class BarclampNetwork::Role < Role
       return if network.allocations.node(nr.node).count != 0
       addr_range = network.ranges.where(:name => nr.node.is_admin? ? "admin" : "host").first
       return if addr_range.nil?
-      addr_range.allocate(nr.node) unless addr_range.nil?
+      # get the node for the hint directly (do not use cached version)
+      node = nr.node(true)
+      # get the suggested ip address (if any) - nil = automatically assign
+      suggestion = node.get_hint[nr.role.name]["ip_v4address"] if node && node.hint[nr.role.name]
+      addr_range.allocate(nr.node, suggestion) unless addr_range.nil?
     end
   end
 


### PR DESCRIPTION
I added this for working with Docker where we cannot set the IP; however, the implementation of hint enables some
really awesome capabilities (not implemented, but now possible).  I have choosen to narrowly implement only the IP 
feature.

This pull includes BOTH docs and bdd tests for this capability in crowbar & network!

The first part in the crowbar framework is to add .hint to nodes and expose this in the API.  I added a helper for the most common usecase - requesting an admin network IP address.

The second part is to have the network role handler use the hint when it allocates the network IP address.  
The allocation part already had logic for suggesting an IP that we were not using until now.  In this case, I simply use the hint to pass in the optional suggestion parameter.

Overall, a very surgical change for a major feature addition.

In the future, hinting can be used to allow users to request operating system, MAC-Name maps, RAID configs and even workloads when a node is created.  
The pattern for this is to add a category for the role doing the operations (e.g.: provisioner-os-installed) and then a key-value pair that the role
would implment ("os=>OpenSuse-13.1") or similar.  

For the MAC-Name mapping, the deployer would use the hint to pre-create the DHCP entry.

 BDD/features/network_role.feature                  |   12 ++++++++++++
 .../app/models/barclamp_network/role.rb            |    6 +++++-
 2 files changed, 17 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 5a75eba6eb8ed557dfb21f1c50c4eef5c4188bcd

Crowbar-Release: development
