### PR TITLE
Make role attributes work, and add some to play around with in CB 2.0 [2/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -34,6 +34,10 @@ roles:
     jig: noop
     flags:
       - server
+    attribs:
+      - name: network_interface_maps
+        description: 'The global set of interface maps that should be used to figure out nic ordering.'
+        map: 'crowbar/interface_map'
 attribs:
   - name: 'nics'
     description: 'Ethernet Interface Ports'


### PR DESCRIPTION
- Make Attrib.get smart. Instead of passing a blob of JSON, it now
  accepts the object it should try to work with. This centralizes the
  logic around what fields in an object are valid places to get
  attributes from, and will fail hard if you pass it something that
  should not work with the attribute system.
- Add matching Attrib.set methods. This provides an abstract interface
  for setting attributes on objects that matches the use of
  Attrib.get.
- Add some attributes to various nodes to lay the groundwork for
  adding logic to the annealer to make it consiter attribute visibility.
- Numerous trivial cleanups to make things work with the above changes.
  
  crowbar.yml                                        |  4 ++
  .../app/models/barclamp_network/network.rb         | 55 ++++++++++++++++++----
  2 files changed, 51 insertions(+), 8 deletions(-)

Crowbar-Pull-ID: cd953079fcc42015c6552d4b6d190cc54e898308

Crowbar-Release: development
