### PR TITLE
CB 2: Make all the things use wants-attrib for smart attribute injection. [2/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -32,8 +32,6 @@ roles:
   # network-server exists to hold interface maps right now.
   - name: network-server
     jig: noop
-    flags:
-      - server
     attribs:
       - name: network_interface_maps
         description: 'The global set of interface maps that should be used to figure out nic ordering.'

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/network.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/network.rb
@@ -126,7 +126,13 @@ class BarclampNetwork::Network < ActiveRecord::Base
         RoleRequire.create!(:role_id => r.id, :requires => "network-server")
         RoleRequire.create!(:role_id => r.id, :requires => "deployer-client") if Rails.env == "production"
         RoleRequire.create!(:role_id => r.id, :requires => "crowbar-installed-node") unless name == "admin"
+        RoleRequireAttrib.create!(:role_id => r.id, :attrib_name => "network_interface_maps")
         # attributes for jig configuraiton
+        ::Attrib.create!(:role_id => r.id,
+                         :barclamp_id => bc.id,
+                         :name => "#{role_name}",
+                         :description => "All data for #{name} network",
+                         :map => "crowbar/network/#{name}")
         ::Attrib.create!(:role_id => r.id,
                          :barclamp_id => bc.id,
                          :name => "#{role_name}_addresses",


### PR DESCRIPTION
This pull request series switches the core Crowbar framework to be
smarter about injecting just the attributes that a role declares that
it needs, instead of just smashing everything that could be in scope
together.

 crowbar.yml                                                         | 2 --
 .../barclamp_network/app/models/barclamp_network/network.rb         | 6 ++++++
 2 files changed, 6 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: dccf04341e8a02b81a47fd321efe6c0256033410

Crowbar-Release: development
