### PR TITLE
Setting miimon value for ubuntu [1/1]

### DIFF
--- a/chef/cookbooks/network/templates/default/interfaces.erb
+++ b/chef/cookbooks/network/templates/default/interfaces.erb
@@ -43,6 +43,7 @@ iface <%= name %> inet manual
     pre-up test -f /sys/class/net/bonding_masters || modprobe bonding
     pre-up grep -qw <%=name%> /sys/class/net/bonding_masters || echo +<%=name%> >/sys/class/net/bonding_masters || true
     pre-up echo <%=i["mode"] %> >/sys/class/net/<%=name%>/bonding/mode || true
+    pre-up echo 100 >/sys/class/net/<%=name%>/bonding/miimon || true
        <% i["slaves"].each do |slave| -%>
     up ip link set <%=slave%> down
     up echo +<%=slave%> > /sys/class/net/<%=name%>/bonding/slaves || true


### PR DESCRIPTION
Setting miimon value to handle network fail-over.
Equivalent to https://github.com/crowbar/barclamp-network/pull/261

 .../network/templates/default/interfaces.erb       |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: 82d89a09566ddd92b83da1d28671c3a5231a1bab

Crowbar-Release: hydrogen
