### PR TITLE
Updated to fix missing miimon on reboot

### DIFF
--- a/chef/cookbooks/network/templates/default/interfaces.erb
+++ b/chef/cookbooks/network/templates/default/interfaces.erb
@@ -43,6 +43,7 @@ iface <%= name %> inet manual
     pre-up test -f /sys/class/net/bonding_masters || modprobe bonding
     pre-up grep -qw <%=name%> /sys/class/net/bonding_masters || echo +<%=name%> >/sys/class/net/bonding_masters || true
     pre-up echo <%=i["mode"] %> >/sys/class/net/<%=name%>/bonding/mode || true
+    pre-up echo 100 >/sys/class/net/<%=name%>/bonding/miimon || true
        <% i["slaves"].each do |slave| -%>
     up ip link set <%=slave%> down
     up echo +<%=slave%> > /sys/class/net/<%=name%>/bonding/slaves || true


### PR DESCRIPTION
https://github.com/crowbar/barclamp-network/pull/262 for roxy.

FWIW, this is Debian/Ubuntu-specific.
