### PR TITLE
Upgrade IPMI barclamp to work with crowbar 2 [2/4]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -36,6 +36,29 @@ roles:
       - name: network_interface_maps
         description: 'The global set of interface maps that should be used to figure out nic ordering.'
         map: 'crowbar/interface_map'
+  - name: network-bmc
+    jig: noop
+    attribs:
+      - name: network-bmc-address
+        description: 'ip address of the bmc interface'
+        map: 'crowbar/network/bmc/address'
+      - name: network-bmc-netmask
+        description: 'ip netmask of the bmc interface'
+        map: 'crowbar/network/bmc/netmask'
+      - name: network-bmc-router
+        description: 'ip address of the bmc router'
+        map: 'crowbar/network/bmc/router'
+      - name: network-bmc-use-vlan
+        description: 'vlan flag'
+        map: 'crowbar/network/bmc/use_vlan'
+      - name: network-bmc-vlan
+        description: 'vlan number'
+        map: 'crowbar/network/bmc/vlan'
+    flags:
+      - implicit
+    requires:
+      - network-server
+
 attribs:
   - name: 'nics'
     description: 'Ethernet Interface Ports'

--- a/crowbar_engine/barclamp_network/app/models/barclamp_network/bmc.rb
+++ b/crowbar_engine/barclamp_network/app/models/barclamp_network/bmc.rb
@@ -1,0 +1,59 @@
+# Copyright 2013, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class BarclampNetwork::Bmc < BarclampNetwork::Role
+
+  def range_name(nr)
+    "bmc"
+  end
+
+  def on_proposed(nr)
+    NodeRole.transaction do
+      if network.allocations.node(nr.node).count == 0
+        # TODO: allocate network and bind admin node interfaces here
+        #Rails.logger.info("Creating BMC network for #{nr.node.name}")
+        # tbd
+      end
+    end
+    Rails.logger.info("Allocating BMC address for #{nr.node.name}")
+    super nr  # allocate address in bmc range
+  end
+
+  def sysdata(nr)
+    # address has been allocated, hook into attributes
+    allocated = network.allocations.node(nr.node).last
+    if allocated.nil?
+      Rails.logger.error("#{name}: Could not find allocated BMC address for #{nr.node.name}!")
+      return   # should never happen
+    end
+    address = allocated.address.addr
+    netmask = allocated.address.netmask
+    router = network.allocations.first.address.addr # assuming the admin node got first allocation
+    use_vlan = network.use_vlan
+    vlan = network.vlan
+
+    Rails.logger.info("#{name}: Creating bmc config for #{nr.node.name} #{address}")
+    # TODO: this should really be done by examining the attributes themselves and building the
+    # json from them.
+    {"crowbar" =>
+         {"network" =>
+              {"bmc" =>
+                   {"address" => address,
+                    "netmask" => netmask,
+                    "router"  => router,
+                    "use_vlan" => use_vlan,
+                    "vlan" => vlan }}}}
+  end
+
+end

--- a/noop/roles/network-bmc/role-template.json
+++ b/noop/roles/network-bmc/role-template.json
@@ -1,0 +1,12 @@
+{
+    "crowbar": {
+        "network" : {
+            "bmc" : {
+                "address" : "0.0.0.0",
+                "netmask" : "0.0.0.0",
+                "router"  : "0.0.0.0",
+                "use_vlan": false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Upgrade IPMI barclamp to work with crowbar 2, including creation and allocation
of bmc network addresses.

 crowbar.yml                                        |   23 ++++++++
 .../app/models/barclamp_network/bmc.rb             |   59 ++++++++++++++++++++
 .../app/models/barclamp_network/role.rb            |    7 ++-
 noop/roles/network-bmc/role-template.json          |   12 ++++
 4 files changed, 100 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 341450787feb53da3651f56f963e1f3cdbc5b98e

Crowbar-Release: development
