### PR TITLE
Adding network API call for role to ip allocation mapping. CES-1424 [2/2]

### DIFF
--- a/crowbar_engine/barclamp_network/app/controllers/barclamp_network/networks_controller.rb
+++ b/crowbar_engine/barclamp_network/app/controllers/barclamp_network/networks_controller.rb
@@ -88,7 +88,20 @@ class BarclampNetwork::NetworksController < ::ApplicationController
     end
     render :json => network.node_allocations(node).map{|a|a.to_s}, :content_type=>cb_content_type(:allocations, "array")
   end
-  
+
+  # Allocations for a role in a network, via node roles
+  def role_allocations
+    network = BarclampNetwork::Network.find_key params[:id]
+    raise "Network #{params[:id]} does not exist" unless network
+
+    r = Role.find_key params[:role]
+    raise "Role #{params[:role]} does not exist" unless r
+    nr = NodeRole.where(:role_id => r.id)
+    addrs = {}
+    nr.map{|nr| addrs[nr.node.name] = network.allocations.node(nr.node).first.address.to_s} unless nr.nil?
+    render :json => addrs, :content_type=>cb_content_type(:allocations, "hash")
+  end
+
   add_help(:update,[:id, :conduit,:team_mode, :use_team, :vlan, :use_vlan],[:put])
   def update
     @network = BarclampNetwork::Network.find_key(params[:id])

--- a/crowbar_engine/barclamp_network/config/routes.rb
+++ b/crowbar_engine/barclamp_network/config/routes.rb
@@ -42,6 +42,7 @@ BarclampNetwork::Engine.routes.draw do
               match 'ip'
               post 'allocate_ip'
               get 'allocations'
+              get 'role_allocations'
             end
           end
         end


### PR DESCRIPTION
Adding network API call and CLI for role to ip allocation mapping. 

CES-1424 - enable smoketest for NTP and DNS barclamps 

 .../barclamp_network/networks_controller.rb        |   15 ++++++++++++++-
 crowbar_engine/barclamp_network/config/routes.rb   |    1 +
 2 files changed, 15 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: d1bebf4e091834477c2252170b9f7f9b81be6d14

Crowbar-Release: development
