### PR TITLE
Change default teaming mode to 1

### DIFF
--- a/chef/data_bags/crowbar/bc-template-network.json
+++ b/chef/data_bags/crowbar/bc-template-network.json
@@ -6,7 +6,7 @@
       "start_up_delay": 30,
       "mode": "single",
       "teaming": {
-        "mode": 5
+        "mode": 1
       },
       "interface_map": [
         {


### PR DESCRIPTION
We're seeing issues from time to time with mode 5.
