### PR TITLE
Replaced barclamp controller initialzer with before filter

### DIFF
--- a/crowbar_framework/app/controllers/network_controller.rb
+++ b/crowbar_framework/app/controllers/network_controller.rb
@@ -16,9 +16,6 @@
 class NetworkController < BarclampController
   # Make a copy of the barclamp controller help
   self.help_contents = Array.new(superclass.help_contents)
-  def initialize
-    @service_object = NetworkService.new logger
-  end
 
   add_help(:allocate_ip,[:id,:network,:range,:name],[:post])
   def allocate_ip
@@ -241,4 +238,9 @@ class NetworkController < BarclampController
     switches
   end
 
+  protected
+
+  def initialize_service
+    @service_object = NetworkService.new logger
+  end
 end


### PR DESCRIPTION
I transfered the service initialize into a before filter. It's a quite dirty practice to overwrite the controller initializer and the way it is done now will result in problems while upgrading to rails 3 or 4.
**This depends on https://github.com/crowbar/barclamp-crowbar/pull/1036**
