### PR TITLE
Fix error message for invalid conduit mapping

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -135,7 +135,7 @@ node["crowbar"]["network"].keys.sort{|a,b|
   base_ifs = conduit_map[conduit]["if_list"]
   # Error out if we were handed an invalid conduit mapping.
   unless base_ifs.all?{|i|i.is_a?(String) && ::Nic.exists?(i)}
-    raise ::ArgumentError.new("Conduit mapping \"#{conduit}\" for network \"#{name}\" is not sane: #{base_ifs.inspect}"
+    raise ::ArgumentError.new("Conduit mapping \"#{conduit}\" for network \"#{name}\" is not sane: #{base_ifs.inspect}")
   end
   base_ifs = base_ifs.map{|i| ::Nic.new(i)}
   Chef::Log.info("Using base interfaces #{base_ifs.map{|i|i.name}.inspect} for network #{name}")


### PR DESCRIPTION
Print the name of the problematic network, instead of the Ruby Object.

(cherry picked from commit cdbdca03140e5aa84ff514388dceeefb00f99be9)
