### PR TITLE
Disable checksum offloading by default

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -303,6 +303,10 @@ Nic.nics.each do |nic|
     end
   end
 
+  unless nic.kind_of?(Nic::Vlan) or nic.kind_of?(Nic::Bond)
+    nic.tx_offloading = node["network"]["enable_tx_offloading"] || false
+  end
+
   if !enslaved
     nic.up
     Chef::Log.info("#{nic.name}: current addresses: #{nic.addresses.map{|a|a.to_s}.sort.inspect}") unless nic.addresses.empty?
@@ -400,9 +404,10 @@ when "suse"
     template "/etc/sysconfig/network/ifcfg-#{nic.name}" do
       source "suse-cfg.erb"
       variables({
-                  :interfaces => ifs,
-                  :nic => nic
-                })
+        :enable_tx_offloading => node["network"]["enable_tx_offloading"] || false,
+        :interfaces => ifs,
+        :nic => nic
+      })
     end
     if ifs[nic.name]["gateway"]
       template "/etc/sysconfig/network/ifroute-#{nic.name}" do

--- a/chef/cookbooks/network/templates/default/suse-cfg.erb
+++ b/chef/cookbooks/network/templates/default/suse-cfg.erb
@@ -19,6 +19,13 @@ STARTMODE=auto
 BOOTPROTO=none
 <% else -%>
 BOOTPROTO=static
+  <% unless @nic.kind_of?(Nic::Vlan) or @nic.kind_of?(Nic::Bond) -%>
+    <% if @enable_tx_offloading -%>
+ETHTOOL_OPTIONS="-K iface tx on"
+    <% else -%>
+ETHTOOL_OPTIONS="-K iface tx off"
+    <% end -%>
+  <% end -%>
 <% end -%>
 <% case
    when @nic.kind_of?(Nic::Bridge) -%>

--- a/chef/data_bags/crowbar/bc-template-network.json
+++ b/chef/data_bags/crowbar/bc-template-network.json
@@ -4,6 +4,7 @@
   "attributes": {
     "network": {
       "start_up_delay": 30,
+      "enable_tx_offloading": false,
       "mode": "single",
       "teaming": {
         "mode": 1

--- a/chef/data_bags/crowbar/bc-template-network.schema
+++ b/chef/data_bags/crowbar/bc-template-network.schema
@@ -13,6 +13,7 @@
           "required": true,
           "mapping": {
             "start_up_delay": { "type": "int", "required": true },
+            "enable_tx_offloading": { "type": "bool" },
             "mode": { "type": "str", "required": true, "pattern": "/^single$|^dual$|^team$/" },
             "teaming": {
               "type": "map",


### PR DESCRIPTION
Most 1g/10g drivers seem to have issues with checksum offloading
when vlans are in use. As those issues are hard to debug and easy
to workaround, lets disable checksum offloading by default.

Add a hidden option in the network.json to be able to set it
to enabled.

https://bugzilla.novell.com/show_bug.cgi?id=888518

(cherry picked from commit b86a120f1ca069f7365dd5e39e10a1766364a90c)
