### PR TITLE
Only add ETHTOOL_OPTIONS when offloading is disabled

### DIFF
--- a/chef/cookbooks/network/templates/default/suse-cfg.erb
+++ b/chef/cookbooks/network/templates/default/suse-cfg.erb
@@ -20,9 +20,7 @@ BOOTPROTO=none
 <% else -%>
 BOOTPROTO=static
   <% unless @nic.kind_of?(Nic::Vlan) or @nic.kind_of?(Nic::Bond) -%>
-    <% if @enable_tx_offloading -%>
-ETHTOOL_OPTIONS="-K iface tx on"
-    <% else -%>
+    <% unless @enable_tx_offloading -%>
 ETHTOOL_OPTIONS="-K iface tx off"
     <% end -%>
   <% end -%>


### PR DESCRIPTION
Otherwise use the defaults. This is to workaround
https://bugzilla.suse.com/show_bug.cgi?id=900112
Which causes wickedd to fail to bring up virtio interfaces on SLES12 when tx/rx
options are present in ETHTOOL_OPTIONS.
