### PR TITLE
Raise min local_port_range to 24576

### DIFF
--- a/chef/cookbooks/network/templates/default/sysctl_10gbe.conf.erb
+++ b/chef/cookbooks/network/templates/default/sysctl_10gbe.conf.erb
@@ -3,7 +3,7 @@
 
 # -- tuning -- #
 # Increase system IP port range to allow for more concurrent connections
-net.ipv4.ip_local_port_range = 10000 65000
+net.ipv4.ip_local_port_range = 24576 65000
 
 # -- 10gbe tuning from Intel ixgb driver README -- #
 


### PR DESCRIPTION
The previous minimum was not enough, as we want to bind
to 11211 (memcached) and that collided eventually. The
default is 32768..61000. Lower and raising the range to add
10000 additional connections should be more than enough.

(cherry picked from commit 64a8fcd0a65500d5c5080f80a130934e513a8ca2)