### PR TITLE
Raise min local_port_range again (bnc#922931)

### DIFF
--- a/chef/cookbooks/network/templates/default/sysctl_10gbe.conf.erb
+++ b/chef/cookbooks/network/templates/default/sysctl_10gbe.conf.erb
@@ -3,7 +3,7 @@
 
 # -- tuning -- #
 # Increase system IP port range to allow for more concurrent connections
-net.ipv4.ip_local_port_range = 24576 65000
+net.ipv4.ip_local_port_range = 27018 65000
 
 #- from https://fasterdata.es.net/host-tuning/linux/
 # allow testing with buffers up to 128MB


### PR DESCRIPTION
The previous minimum was not enough, as mongodb (used by ceilometer) binds to
27017.

https://bugzilla.suse.com/show_bug.cgi?id=922931