### PR TITLE
Set MTU on the device during chef-client run

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -328,6 +328,10 @@ Nic.nics.each do |nic|
     nic.tx_offloading = node["network"]["enable_tx_offloading"] || false
   end
 
+  if ifs[nic.name]["mtu"]
+    nic.mtu = ifs[nic.name]["mtu"]
+  end
+
   if !enslaved
     nic.up
     Chef::Log.info("#{nic.name}: current addresses: #{nic.addresses.map{|a|a.to_s}.sort.inspect}") unless nic.addresses.empty?


### PR DESCRIPTION
Previously the MTU was only set in the config file and would only get activated
during the next reboot (or ifup call).